### PR TITLE
update setup.py on python3 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/py#thon
+#!/usr/bin/python3
 # $Id$
 
 import glob

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # $Id$
 
 import glob


### PR DESCRIPTION
same typo in shebang line as master branch. changed to python3 (since python3 branch). i've only ever used fedora, and it distinguishes between python2 and python3 executables. can someone confirm it's the same for others?