### PR TITLE
Flags management inside SMBv1 stack

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -2437,6 +2437,9 @@ class SMB:
     def talk_unicode(self, value):
 	self.__unicode_flag = SMB.FLAGS2_UNICODE if value else 0
 
+    def is_talking_unicode(self):
+	return self.__unicode_flag == SMB.FLAGS2_UNICODE
+
     def get_timeout(self):
         return self.__timeout
 

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -2435,7 +2435,7 @@ class SMB:
         return prev_timeout
 
     def talk_unicode(self, value):
-	self.__unicode_flag = SMB.FLAGS2_UNICODE if value else 0
+	self.__unicode_flag = (SMB.FLAGS2_UNICODE if value else 0)
 
     def is_talking_unicode(self):
 	return self.__unicode_flag == SMB.FLAGS2_UNICODE

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3761,7 +3761,7 @@ class SMB:
             findFirstParameter['Flags'] = SMB_FIND_RETURN_RESUME_KEYS | SMB_FIND_CLOSE_AT_EOS
             findFirstParameter['InformationLevel'] = SMB_FIND_FILE_BOTH_DIRECTORY_INFO
             findFirstParameter['SearchStorageType'] = 0
-            findFirstParameter['FileName'] = path + '\x00\x00' if self.__flags2 & SMB.FLAGS2_UNICODE else '\x00'
+            findFirstParameter['FileName'] = path + ('\x00\x00' if self.__flags2 & SMB.FLAGS2_UNICODE else '\x00')
             self.send_trans2(tid, SMB.TRANS2_FIND_FIRST2, '\x00', findFirstParameter, '')
             files = [ ]
 
@@ -3804,7 +3804,7 @@ class SMB:
                         findNextParameter['InformationLevel'] = SMB_FIND_FILE_BOTH_DIRECTORY_INFO
                         findNextParameter['ResumeKey'] = 0
                         findNextParameter['Flags'] = SMB_FIND_RETURN_RESUME_KEYS | SMB_FIND_CLOSE_AT_EOS
-                        findNextParameter['FileName'] = resume_filename + '\x00'
+                        findNextParameter['FileName'] = resume_filename + ('\x00\x00' if self.__flags2 & SMB.FLAGS2_UNICODE else '\x00')
                         self.send_trans2(tid, SMB.TRANS2_FIND_NEXT2, '\x00', findNextParameter, '')
                         findData = ''
                         findNext2ParameterBlock = ''

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3243,9 +3243,8 @@ class SMB:
             if ntlmChallenge.fields.has_key('Version'):
                 version = ntlmChallenge['Version']
 
-                self.__server_os_major = ord(version[0])
-                self.__server_os_minor = ord(version[1])
-                self.__server_os_build = unpack('<H',version[2:4])[0]
+                if len(version) >= 4:
+                   self.__server_os_major, self.__server_os_minor, self.__server_os_build = unpack('<BBH',version[:4])
 
             type3, exportedSessionKey = ntlm.getNTLMSSPType3(auth, respToken['ResponseToken'], user, password, domain, lmhash, nthash, use_ntlmv2 = use_ntlmv2)
 

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -2607,7 +2607,6 @@ class SMB:
             return parsePacket( NewSMBPacket( data = negPacket))
 
     def tree_connect(self, path, password = '', service = SERVICE_ANY):
-	# SMB_COM_TREE_CONNECT shouldn't encode unicode, from [MS-CIFS], 2.2.4.50.1 -> no unicode here!
         LOG.warning("[MS-CIFS] This is an original Core Protocol command.This command has been deprecated.Client Implementations SHOULD use SMB_COM_TREE_CONNECT_ANDX")
 
         # return 0x800

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3960,7 +3960,7 @@ class SMB:
             smb['Flags1'] = SMB.FLAGS1_PATHCASELESS
             smb['Flags2'] = self.__unicode_flag
             createDir = SMBCommand(SMB.SMB_COM_DELETE_DIRECTORY)
-            createDir['Data'] = SMBDeleteDirectory_Data(flags=self.__unicode_path)
+            createDir['Data'] = SMBDeleteDirectory_Data(flags=self.__unicode_flag)
             createDir['Data']['DirectoryName'] = path
             smb.addCommand(createDir)
 

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -254,11 +254,24 @@ class SMB3:
     def getServerOS(self):
         return self._Session['ServerOS']
 
+    def getServerOSMajor(self):
+        return self._Session['ServerOSMajor']
+
+    def getServerOSMinor(self):
+        return self._Session['ServerOSMinor']
+
+    def getServerOSBuild(self):
+        return self._Session['ServerOSBuild']
+
     def isGuestSession(self):
         return self._Session['SessionFlags'] & SMB2_SESSION_FLAG_IS_GUEST 
 
     def setTimeout(self, timeout):
         self._timeout = timeout
+
+    def talkUnicode(self, value):
+	# smb2 always use unicode
+	pass
 
     @contextmanager
     def useTimeout(self, timeout):
@@ -720,6 +733,11 @@ class SMB3:
                 # Parse Version to know the target Operating system name. Not provided elsewhere anymore
                 if ntlmChallenge.fields.has_key('Version'):
                     version = ntlmChallenge['Version']
+
+		    self._Session["ServerOSMajor"] = ord(version[0])
+		    self._Session["ServerOSMinor"] = ord(version[1])
+		    self._Session["ServerOSBuild"] = struct.unpack('<H',version[2:4])[0]
+
                     if len(version) >= 4:
                         self._Session['ServerOS'] = "Windows %d.%d Build %d" % (ord(version[0]), ord(version[1]), struct.unpack('<H',version[2:4])[0])
 
@@ -1514,12 +1532,16 @@ class SMB3:
     get_remote_name            = getServerName
     get_remote_host            = getServerIP
     get_server_os              = getServerOS
+    get_server_os_major        = getServerOSMajor
+    get_server_os_minor        = getServerOSMinor
+    get_server_os_build        = getServerOSBuild
     tree_connect_andx          = connectTree
     tree_connect               = connectTree
     connect_tree               = connectTree
     disconnect_tree            = disconnectTree 
     set_timeout                = setTimeout
     use_timeout                = useTimeout
+    talk_unicode               = talkUnicode
     stor_file                  = storeFile
     retr_file                  = retrieveFile
     list_path                  = listPath

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -730,10 +730,6 @@ class SMB3:
                 if ntlmChallenge.fields.has_key('Version'):
                     version = ntlmChallenge['Version']
 
-		    self._Session["ServerOSMajor"] = ord(version[0])
-		    self._Session["ServerOSMinor"] = ord(version[1])
-		    self._Session["ServerOSBuild"] = struct.unpack('<H',version[2:4])[0]
-
                     if len(version) >= 4:
                         self._Session['ServerOS'] = "Windows %d.%d Build %d" % (ord(version[0]), ord(version[1]), struct.unpack('<H',version[2:4])[0])
                         self._Session["ServerOSMajor"] = ord(version[0])

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -273,6 +273,9 @@ class SMB3:
 	# smb2 always use unicode
 	pass
 
+    def isTalkingUnicode(self):
+	return True
+
     @contextmanager
     def useTimeout(self, timeout):
         prev_timeout = self.getTimeout(timeout)
@@ -1542,6 +1545,7 @@ class SMB3:
     set_timeout                = setTimeout
     use_timeout                = useTimeout
     talk_unicode               = talkUnicode
+    is_talking_unicode         = isTalkingUnicode
     stor_file                  = storeFile
     retr_file                  = retrieveFile
     list_path                  = listPath

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -269,13 +269,6 @@ class SMB3:
     def setTimeout(self, timeout):
         self._timeout = timeout
 
-    def talkUnicode(self, value):
-	# smb2 always use unicode
-	pass
-
-    def isTalkingUnicode(self):
-	return True
-
     @contextmanager
     def useTimeout(self, timeout):
         prev_timeout = self.getTimeout(timeout)
@@ -1547,8 +1540,6 @@ class SMB3:
     disconnect_tree            = disconnectTree 
     set_timeout                = setTimeout
     use_timeout                = useTimeout
-    talk_unicode               = talkUnicode
-    is_talking_unicode         = isTalkingUnicode
     stor_file                  = storeFile
     retr_file                  = retrieveFile
     list_path                  = listPath

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -139,6 +139,15 @@ class SMBConnection:
     def getServerOS(self):
         return self._SMBConnection.get_server_os()
 
+    def getServerOSMajor(self):
+        return self._SMBConnection.get_server_os_major()
+
+    def getServerOSMinor(self):
+        return self._SMBConnection.get_server_os_minor()
+
+    def getServerOSBuild(self):
+        return self._SMBConnection.get_server_os_build()
+
     def doesSupportNTLMv2(self):
         return self._SMBConnection.doesSupportNTLMv2()
 
@@ -310,10 +319,10 @@ class SMBConnection:
         """
 
         if self.getDialect() == smb.SMB_DIALECT:
-            pathName = string.replace(pathName, '/', '\\')
+	    pathName = pathName.replace('/', '\\').encode('utf-16le')
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-            ntCreate['Data']       = smb.SMBNtCreateAndX_Data()
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=smb.SMB.FLAGS2_UNICODE)
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -324,6 +333,7 @@ class SMBConnection:
             ntCreate['Parameters']['SecurityFlags'] = securityFlags
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
+	    ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:
                 LOG.error("CreateContexts not supported in SMB1")
@@ -349,10 +359,10 @@ class SMBConnection:
         """
 
         if self.getDialect() == smb.SMB_DIALECT:
-            pathName = string.replace(pathName, '/', '\\')
+	    pathName = pathName.replace('/', '\\').encode('utf-16le')
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-            ntCreate['Data']       = smb.SMBNtCreateAndX_Data()
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=smb.SMB.FLAGS2_UNICODE)
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -363,6 +373,7 @@ class SMBConnection:
             ntCreate['Parameters']['SecurityFlags'] = securityFlags
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
+	    ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:
                 LOG.error("CreateContexts not supported in SMB1")
@@ -618,6 +629,9 @@ class SMBConnection:
             return self._SMBConnection.set_timeout(timeout)
         except (smb.SessionError, smb3.SessionError), e:
             raise SessionError(e.get_error_code())
+
+    def talkUnicode(self, value):
+	self._SMBConnection.talk_unicode(value)
 
     def getSessionKey(self):
         if self.getDialect() == smb.SMB_DIALECT:

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -320,11 +320,11 @@ class SMBConnection:
 
         if self.getDialect() == smb.SMB_DIALECT:
 	    pathName = pathName.replace('/', '\\').encode('utf-16le')
-	    pathName = pathName.encode('utf-16le') if self._SMBConnection.isTalkingUnicode() else pathName
+	    pathName = pathName.encode('utf-16le') if self.isTalkingUnicode() else pathName
 
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self._SMBConnection.isTalkingUnicode())
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self.isTalkingUnicode())
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -336,7 +336,7 @@ class SMBConnection:
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
 
-	    if self._SMBConnection.isTalkingUnicode():
+	    if self.isTalkingUnicode():
 	    	ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:
@@ -364,11 +364,11 @@ class SMBConnection:
 
         if self.getDialect() == smb.SMB_DIALECT:
 	    pathName = pathName.replace('/', '\\').encode('utf-16le')
-	    pathName = pathName.encode('utf-16le') if self._SMBConnection.isTalkingUnicode() else pathName
+	    pathName = pathName.encode('utf-16le') if self.isTalkingUnicode() else pathName
 
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self._SMBConnection.isTalkingUnicode())
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self.isTalkingUnicode())
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -380,7 +380,7 @@ class SMBConnection:
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
 
-	    if self._SMBConnection.isTalkingUnicode():
+	    if self.isTalkingUnicode():
 	    	ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -320,9 +320,11 @@ class SMBConnection:
 
         if self.getDialect() == smb.SMB_DIALECT:
 	    pathName = pathName.replace('/', '\\').encode('utf-16le')
+	    pathName = pathName.encode('utf-16le') if self._SMBConnection.isTalkingUnicode() else pathName
+
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=smb.SMB.FLAGS2_UNICODE)
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self._SMBConnection.isTalkingUnicode())
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -333,7 +335,9 @@ class SMBConnection:
             ntCreate['Parameters']['SecurityFlags'] = securityFlags
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
-	    ntCreate['Data']['Pad'] = 0x0
+
+	    if self._SMBConnection.isTalkingUnicode():
+	    	ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:
                 LOG.error("CreateContexts not supported in SMB1")
@@ -360,9 +364,11 @@ class SMBConnection:
 
         if self.getDialect() == smb.SMB_DIALECT:
 	    pathName = pathName.replace('/', '\\').encode('utf-16le')
+	    pathName = pathName.encode('utf-16le') if self._SMBConnection.isTalkingUnicode() else pathName
+
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
             ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=smb.SMB.FLAGS2_UNICODE)
+	    ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=self._SMBConnection.isTalkingUnicode())
             ntCreate['Parameters']['FileNameLength']= len(pathName)
             ntCreate['Parameters']['AccessMask']    = desiredAccess
             ntCreate['Parameters']['FileAttributes']= fileAttributes
@@ -373,7 +379,9 @@ class SMBConnection:
             ntCreate['Parameters']['SecurityFlags'] = securityFlags
             ntCreate['Parameters']['CreateFlags']   = 0x16
             ntCreate['Data']['FileName'] = pathName
-	    ntCreate['Data']['Pad'] = 0x0
+
+	    if self._SMBConnection.isTalkingUnicode():
+	    	ntCreate['Data']['Pad'] = 0x0
 
             if createContexts is not None:
                 LOG.error("CreateContexts not supported in SMB1")

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -60,7 +60,7 @@ class SMBConnection:
         if manualNegotiate is False:
             self.negotiateSession(preferredDialect)
 
-    def negotiateSession(self, preferredDialect=None, flags1=0, flags2=0,
+    def negotiateSession(self, preferredDialect=None, flags1=smb.SMB.FLAGS1_PATHCASELESS | smb.SMB.FLAGS1_CANONICALIZED_PATHS, flags2=smb.SMB.FLAGS2_EXTENDED_SECURITY | smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_LONG_NAMES,
                          negoData='\x02NT LM 0.12\x00\x02SMB 2.002\x00\x02SMB 2.???\x00'):
         """
         Perform protocol negotiation

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -640,6 +640,9 @@ class SMBConnection:
 
     def talkUnicode(self, value):
 	self._SMBConnection.talk_unicode(value)
+ 
+    def isTalkingUnicode(self):
+	self._SMBConnection.is_talking_unicode()
 
     def getSessionKey(self):
         if self.getDialect() == smb.SMB_DIALECT:

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -642,7 +642,7 @@ class SMBConnection:
 	self._SMBConnection.talk_unicode(value)
  
     def isTalkingUnicode(self):
-	self._SMBConnection.is_talking_unicode()
+	return self._SMBConnection.is_talking_unicode()
 
     def getSessionKey(self):
         if self.getDialect() == smb.SMB_DIALECT:


### PR DESCRIPTION
Hi mate,

Here is the PR implementing points 3) and 4) discussed in #51. I did the followings:
* Dropped `smb['Flags1']` and `smb['Flags2']` initializations everytime we call `NewSMBPacket()`. Flags were already set in sendSMB().
* Defined default flags in the SMB contructor to restore the default behavior if `manualNegotiate` is not used
* Removed `self.__is_pathcaseless` which was unused
* Disabled unicode flag during the authentication process. The remote server returns an error code if unicode is used.