### PR TITLE
raise socket error instead of exception

### DIFF
--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -860,8 +860,8 @@ class NetBIOSTCPSession(NetBIOSSession):
             af, socktype, proto, canonname, sa = socket.getaddrinfo(peer[0], peer[1], 0, socket.SOCK_STREAM)[0]
             sock = socket.socket(af, socktype, proto)
             sock.connect(sa)
-        except Exception, e:
-            raise Exception("%s (%s:%s)" % (e, peer[0], peer[1]))
+        except socket.error, e:
+            raise socket.error("Connection error (%s:%s)" % (peer[0], peer[1]), e)
         return sock
 
     def send_packet(self, data):


### PR DESCRIPTION
In NetBIOSTCPSession._setup_connection the only way to differentiate socket.error from other exceptions is by the exception message.
Change to catch socket.error and raise a new socket.error with additional information.
 