### PR TITLE
fixed __init__() error in smbrelayx.py and added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -84,7 +84,7 @@ class doAttack(Thread):
             samHashes = None
             remoteOps = None
             try:
-                remoteOps  = RemoteOperations(self.__SMBConnection)
+                remoteOps  = RemoteOperations(self.__SMBConnection, False)
                 remoteOps.enableRegistry()
                 bootKey = remoteOps.getBootKey()
                 samFileName = remoteOps.saveSAM()


### PR DESCRIPTION
Hey man! 

I was playing around with smbrelayx.py and noticed the following error when a successful auth attempt happens:
```
Impacket v0.9.14-dev - Copyright 2002-2015 Core Security Technologies

[*] Running in relay mode
[*] Config file parsed
[*] Setting up SMB Server
[*] Setting up HTTP Server

[*] Servers started, waiting for connections
[*] Incoming connection (172.16.206.133,49225)
[*] SMBD: Received connection from 172.16.206.133, attacking target 172.16.206.130
[-] Authenticating against 172.16.206.130 as drugoutcove-pc\drugdealerboss FAILED
[-] Authenticating against 172.16.206.130 as drugoutcove-pc\drugdealerboss FAILED
[-] Authenticating against 172.16.206.130 as drugoutcove-pc\drugdealerboss FAILED
[-] Authenticating against 172.16.206.130 as drugoutcove-pc\drugdealerboss FAILED
[*] Handle: [Errno 104] Connection reset by peer
[*] Closing down connection (172.16.206.133,49225)
[*] Remaining connections ['SMBRelay']
[*] Incoming connection (172.16.206.133,49226)
[*] SMBD: Received connection from 172.16.206.133, attacking target 172.16.206.130
[*] Authenticating against 172.16.206.130 as drugoutcove-pc\drugdealerboss SUCCEED
[-] __init__() takes exactly 3 arguments (2 given)
[-] TreeConnectAndX not found C$
[-] TreeConnectAndX not found C$
[-] TreeConnectAndX not found C$.
[-] TreeConnectAndX not found C$.
[*] Disconnecting Share(1:IPC$)
[*] Handle: [Errno 104] Connection reset by peer
[*] Closing down connection (172.16.206.133,49226)
[*] Remaining connections ['SMBRelay']
```
this PR fixes that error , plus I added a .gitignore file

Cheers