### PR TITLE
use existing SMB transport if possible instead of fixed 135 port

### DIFF
--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -128,7 +128,7 @@ class RPCDump:
         #dce.bind(epm.MSRPC_UUID_PORTMAP)
         #rpcepm = epm.DCERPCEpm(dce)
 
-        resp = epm.hept_lookup(rpctransport.get_dip())
+        resp = epm.hept_lookup(None, dce=dce)
 
         dce.disconnect()
 

--- a/impacket/dcerpc/v5/epm.py
+++ b/impacket/dcerpc/v5/epm.py
@@ -881,11 +881,15 @@ class ept_mapResponse(NDRCALL):
 # HELPER FUNCTIONS
 ################################################################################
 
-def hept_lookup(destHost, inquiry_type = RPC_C_EP_ALL_ELTS, objectUUID = NULL, ifId = NULL, vers_option = RPC_C_VERS_ALL,  entry_handle = ept_lookup_handle_t(), max_ents = 499):
-    stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
-    rpctransport = transport.DCERPCTransportFactory(stringBinding)
-    dce = rpctransport.get_dce_rpc()
-    dce.connect()
+def hept_lookup(destHost, inquiry_type = RPC_C_EP_ALL_ELTS, objectUUID = NULL, ifId = NULL, vers_option = RPC_C_VERS_ALL,  entry_handle = ept_lookup_handle_t(), max_ents = 499, dce = None):
+    if dce is None:
+        stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
+        rpctransport = transport.DCERPCTransportFactory(stringBinding)
+        dce = rpctransport.get_dce_rpc()
+        dce.connect()
+    else:
+        destHost = None
+
     dce.bind(MSRPC_UUID_PORTMAP)
     request = ept_lookup()
     request['inquiry_type'] = inquiry_type
@@ -909,11 +913,14 @@ def hept_lookup(destHost, inquiry_type = RPC_C_EP_ALL_ELTS, objectUUID = NULL, i
         tmpEntry['object'] = entry['object'] 
         tmpEntry['annotation'] = ''.join(entry['annotation'])
         tmpEntry['tower'] = EPMTower(''.join(entry['tower']['tower_octet_string']))
-        entries.append(tmpEntry)        
-    dce.disconnect()
+        entries.append(tmpEntry)
+
+    if destHost is not None:
+        dce.disconnect()
+
     return entries
 
-def hept_map(destHost, remoteIf, dataRepresentation = uuidtup_to_bin(('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')), protocol = 'ncacn_np'): 
+def hept_map(destHost, remoteIf, dataRepresentation = uuidtup_to_bin(('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')), protocol = 'ncacn_np'):
     stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
     rpctransport = transport.DCERPCTransportFactory(stringBinding)
     dce = rpctransport.get_dce_rpc()


### PR DESCRIPTION
Thanks for all of members of this good project.

I am studying on how to call DCOM/RPC via SMB 445 port, without 135 port(the EndPointMapper,  because i hate port 135, they can not be combined with "net use " authentication).

I have tried rpcdump.py, but found that: 
<b>it ALWAYS use 135 port to dump interfaces, even if i specified 445/SMB parameters. </b>

<b>There are many other places have same problem, you can search "[135]". i will modify them when necessary.</b>
````
Occurrences of '[135]' in Project
impacket
build/lib/impacket/dcerpc/v5
epm.py
        stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
    stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
impacket/dcerpc/v5
epm.py
        stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
    stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
impacket/testcases/SMB_RPC
test_epm.py
        self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
        self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
test_mgmt.py
        self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
        self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
````

I have only modified epm.py::hept_lookup and rpcdump.py then tested rpcdump.py on Mac OS X Yosimite 10.10.5, Python 2.7, the Windows Server is Windows Srv 2012R2 or Windows 10 Pro or Windows Srv 2016ES.

<b>There are an important step to reproduce the problem and test for excluding port 135:</b>

Add a firewall rule manually to disable port 135 by command:
````shell
netsh advfirewall firewall add rule name="stop listening at TCP port 135" protocol=TCP dir=in localport=135 action=block enable=yes
````

Furthermore, i even disabled all ports except 445(SMB), rpcdump.py works only with 445 port!
````shell
netsh advfirewall firewall add rule name="stop listening at all TCP ports except 445(SMB)" protocol=TCP dir=in localport=1-444,446-65535 action=block enable=yes
````

This is my test result:
````shell
$ nmap -Pn 192.168.99.100 -p 53,88,137-139,389,464,135,445
PORT    STATE    SERVICE
53/tcp  filtered domain
88/tcp  filtered kerberos-sec
135/tcp filtered msrpc
137/tcp filtered netbios-ns
138/tcp filtered netbios-dgm
139/tcp filtered netbios-ssn
389/tcp filtered ldap
445/tcp open     microsoft-ds     #you can confirm only 445 port is open, others is blocked
464/tcp filtered kpasswd5


$ rpcdump.py admin:password@192.168.99.100 445/SMB
Impacket v0.9.14-dev - Copyright 2002-2015 Core Security Technologies

[*] Retrieving endpoint list from 192.168.99.100
[*] Trying protocol 445/SMB...
Protocol: N/A 
Provider: N/A 
UUID    : 0D3E2735-CEA0-4ECC-A9E2-41A2D81AED4E v1.0 
Bindings: 
          ncalrpc:[actkernel]
          ncalrpc:[umpo]

Protocol: N/A 
Provider: iphlpsvc.dll 
UUID    : 552D076A-CB29-4E44-8B6A-D15E59E2C0AF v1.0 IP Transition Configuration endpoint
Bindings: 
          ncacn_np:\\WIN2016SERVER[\pipe\SessEnvPublicRpc]
          ncalrpc:[SessEnvPrivateRpc]
          ncalrpc:[DeviceSetupManager]
          ncacn_ip_tcp:192.168.99.100[49666]
          ncalrpc:[LRPC-ad6309cf6319900769]
          ncalrpc:[ubpmtaskhostchannel]
          ncacn_np:\\WIN2016SERVER[\PIPE\atsvc]
          ncalrpc:[LRPC-7e49c8f12c45326580]
          ncalrpc:[senssvc]
          ncalrpc:[IUserProfile2]
          ncalrpc:[OLECD089687C6C4C766EBF3CD1F326E]

Protocol: N/A 
Provider: schedsvc.dll 
UUID    : 0A74EF1C-41A4-4E06-83AE-DC74FB1CDD53 v1.0 
.... ....

[*] Received 499 endpoints.                #the result  is same as with 135/TCP

````



