### PR TITLE
WMI: Allow setting packet privacy authentication level

### DIFF
--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -27,6 +27,7 @@ from impacket import version
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
 if __name__ == '__main__':
     import cmd
@@ -124,6 +125,7 @@ if __name__ == '__main__':
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    group.add_argument('-auth-level-pkt-privacy', action="store_true", help='authentication level: packet privacy (for example CIM path "root/MSCluster" would require that authentication level by default)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication (128 or 256 bits)')
 
@@ -168,6 +170,8 @@ if __name__ == '__main__':
         iInterface = dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login,wmi.IID_IWbemLevel1Login)
         iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
         iWbemServices= iWbemLevel1Login.NTLMLogin(options.namespace, NULL, NULL)
+        if options.auth_level_pkt_privacy:
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
         iWbemLevel1Login.RemRelease()
 
         shell = WMIQUERY(iWbemServices)


### PR DESCRIPTION
Some CIM namespaces require authentication level of "packet privacy". One example is the "root/MSCluster" CIM namespace.

The wmiquery script did not allow setting that authentication level and for a non-expert user, that means that the usability of this package may be somewhat diminished.

This pull request adds another argument that allows setting this authentication level.
