### PR TITLE
SMB3.create: define CreateContextsOffset and CreateContextsLength when applicable

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -918,6 +918,9 @@ class SMB3:
 
         if createContexts is not None:
             smb2Create['Buffer'] += createContexts
+            # Offset = SMB2_HEADER (64) + CREATE_REQUEST_HEADER (56) + NameLength
+            smb2Create['CreateContextsOffset'] = 64 + 56 + smb2Create['NameLength']
+            smb2Create['CreateContextsLength'] = len(createContexts)
         else:
             smb2Create['CreateContextsOffset'] = 0
             smb2Create['CreateContextsLength'] = 0


### PR DESCRIPTION
When providing createContexts in a SMB3 create call, the buffer is set
accordingly, but not the offset and length fields. This causes the createContext
data to be ignored by the server.

This patch tries to fix this by specifying the offset and length. The offset is
determined by adding the size of the SMB2 and CREATE_REQUEST headers to the
name length.