### PR TITLE
SMB3.create: use proper method to determine SMB2 and SMB2Create headers sizes

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -918,8 +918,7 @@ class SMB3:
 
         if createContexts is not None:
             smb2Create['Buffer'] += createContexts
-            # Offset = SMB2_HEADER (64) + CREATE_REQUEST_HEADER (56) + NameLength
-            smb2Create['CreateContextsOffset'] = 64 + 56 + smb2Create['NameLength']
+            smb2Create['CreateContextsOffset'] = len(SMB2Packet()) + SMB2Create.SIZE + smb2Create['NameLength']
             smb2Create['CreateContextsLength'] = len(createContexts)
         else:
             smb2Create['CreateContextsOffset'] = 0


### PR DESCRIPTION
This prevents from needing a commentary to explain what those hard-coded values
stand for.