### PR TITLE
Retrieve user principal name from CCache file

### DIFF
--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -247,6 +247,11 @@ class SMBConnection:
                 # No cache present
                 pass
             else:
+                # retrieve user and domain information from CCache file if needed
+                if user == '' and len(ccache.principal.components) > 0:
+                    user=ccache.principal.components[0]['data']
+                if domain == '':
+                    domain = ccache.principal.realm['data']
                 LOG.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
                 principal = 'cifs/%s@%s' % (self.getRemoteHost().upper(), domain.upper())
                 creds = ccache.getCredential(principal)

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -682,6 +682,11 @@ class MSSQL:
                 # No cache present
                 pass
             else:
+                # retrieve user and domain information from CCache file if needed
+                if user == '' and len(ccache.principal.components) > 0:
+                    user=ccache.principal.components[0]['data']
+                if domain == '':
+                    domain = ccache.principal.realm['data']
                 LOG.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
                 principal = 'MSSQLSvc/%s.%s:%d' % (self.server, domain, self.port)
                 creds = ccache.getCredential(principal)


### PR DESCRIPTION
If needed, retrieve user and domaine information from KRB5 CCache file.
This simplifies examples command-line, as user only needs to export
KRB5CCNAME environment variable after a successful authentication using
kinit and do not need to specify user principal name on command line:
$ export KRB5CCNAME=/tmp/krb5cc_1000
$ smbclient.py -k win2012-dc1.vulnerable.local