### PR TITLE
UnboundLocalError in smbconnection.readFile() when recieving STATUS_END_OF_FILE error

### DIFF
--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -488,7 +488,7 @@ class SMBConnection:
             except (smb.SessionError, smb3.SessionError), e:
                 if e.get_error_code() == nt_errors.STATUS_END_OF_FILE:
                     toRead = ''
-                    pass
+                    break
                 else:
                     raise SessionError(e.get_error_code())
 


### PR DESCRIPTION
Hey mate,

While working on CME I encountered this error:
```
Traceback (most recent call last):
  File "/home/byt3bl33d3r/Devel/CrackMapExec/core/spider/smbspider.py", line 92, in search_content
    contents = rfile.read(4096)
  File "/home/byt3bl33d3r/Devel/CrackMapExec/core/remotefile.py", line 23, in read
    data =  self.__smbConnection.readFile(self.__tid, self.__fid, self.__currentOffset, bytesToRead)
  File "/home/byt3bl33d3r/.virtualenvs/CME/lib/python2.7/site-packages/impacket/smbconnection.py", line 495, in readFile
    data += bytesRead
UnboundLocalError: local variable 'bytesRead' referenced before assignment
```
Seems like the culprit is the ```pass``` statement here https://github.com/CoreSecurity/impacket/blob/master/impacket/smbconnection.py#L491

I think this error should break out of the while loop (not 100% sure so please correct me if I'm wrong.)

Cheers