### PR TITLE
Save dumped SAM hashes to log file

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -906,7 +906,7 @@ class SAMHashes(OfflineRegistry):
 
         return decryptedHash
 
-    def dump(self):
+    def dump(self, dumpFile):
         NTPASSWORD = "NTPASSWORD\0"
         LMPASSWORD = "LMPASSWORD\0"
 
@@ -956,6 +956,7 @@ class SAMHashes(OfflineRegistry):
             answer =  "%s:%d:%s:%s:::" % (userName, rid, hexlify(lmHash), hexlify(ntHash))
             self.__itemsFound[rid] = answer
             print answer
+	    self.export(dumpFile)
 
     def export(self, fileName):
         if len(self.__itemsFound) > 0:

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -113,7 +113,7 @@ class doAttack(Thread):
                     remoteOps._RemoteOperations__serviceDeleted = True
                     samFileName = remoteOps.saveSAM()
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
-                    samHashes.dump()
+                    samHashes.dump(self.__SMBConnection.getRemoteHost())
                     logging.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
             except Exception, e:
                 logging.error(str(e))


### PR DESCRIPTION
@asolino New pull request where i used the export function. For output filename i used the remote IP address. If in the future multi target is added, this would make it easier to create a SAM dump for each system.