### PR TITLE
TGS-Response code to work with windows AD

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -367,7 +367,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
 
     encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
 
-    newSessionKey = Key(cipher.enctype, str(encTGSRepPart['key']['keyvalue']))
+    newSessionKey = Key(encTGSRepPart['key']['keytype'], str(encTGSRepPart['key']['keyvalue']))
 
     # Check we've got what we asked for
     res = decoder.decode(r, asn1Spec = TGS_REP())[0]

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -343,8 +343,12 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
     reqBody['till'] = KerberosTime.to_asn1(now)
     reqBody['nonce'] = random.getrandbits(31)
     seq_set_iter(reqBody, 'etype',
-                      (int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                       int(cipher.enctype)))
+                      (
+                          int(constants.EncryptionTypes.rc4_hmac.value),
+                          int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+                          int(cipher.enctype)
+                       )
+                )
 
     message = encoder.encode(tgsReq)
 


### PR DESCRIPTION
With these changes I could fetch TGS responses from Windows AD SPN user accounts (kerberoast attack).
The AD was always replying with error on the TGS-REQ, when the etype was not containing rc4_hmac (int 23), after that was fixed it seemed that impacket was still trying to use the cipher type specified, hence the second commit.

I don't know whether  it breaks something in your examples/code flows, but according to my research it should be implemented this way.

BTW !!!! awesome work guys!!!!