### PR TITLE
Added option in smbrelayx to specify authentication status code to be sent to requesting client.

### DIFF
--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -847,6 +847,15 @@ class SMBRelayServer(Thread):
         self.command = command
 
     def setReturnStatus(self, returnStatus):
+        # Specifies return status after successful relayed authentication to return
+        # to the connecting client. This comes useful when we don't want the connecting
+        # client to store successful credentials in his memory. Valid statuses:
+        # STATUS_SUCCESS - denotes that the connecting client passed valid credentials,
+        #                   which will make him store them accordingly.
+        # STATUS_ACCESS_DENIED - may occur for instance when the client is not a Domain Admin,
+        #                       and got configured Remote UAC, thus preventing connection to ADMIN$
+        # STATUS_LOGON_FAILURE - which will tell the connecting client that the passed credentials
+        #                       are invalid.
         self.returnStatus = {
             'success' : STATUS_SUCCESS,
             'denied' : STATUS_ACCESS_DENIED,
@@ -898,6 +907,10 @@ if __name__ == '__main__':
     exeFile = options.e
     Command = options.c
     returnStatus = options.s
+
+    if returnStatus.lower() not in ['success', 'denied', 'logon_failure']:
+        logging.error("Invalid return status code specified. Please use on of the following:\n\tsuccess, denied or logon_failure")
+        sys.exit(1)
 
     for server in RELAY_SERVERS:
         s = server(options.outputfile)

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -396,11 +396,12 @@ class SMBClient(smb.SMB):
 
 class HTTPRelayServer(Thread):
     class HTTPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
-        def __init__(self, server_address, RequestHandlerClass, target, exeFile, command, mode, outputFile):
+        def __init__(self, server_address, RequestHandlerClass, target, exeFile, command, mode, outputFile, returnStatus = STATUS_SUCCESS):
             self.target = target
             self.exeFile = exeFile
             self.command = command
             self.mode = mode
+            self.returnStatus = returnStatus
             self.outputFile = outputFile
 
             SocketServer.TCPServer.__init__(self,server_address, RequestHandlerClass)
@@ -558,6 +559,7 @@ class SMBRelayServer(Thread):
         self.machineAccount = None
         self.machineHashes = None
         self.exeFile = None
+        self.returnStatus = STATUS_SUCCESS
         self.command = None
 
         # Here we write a mini config for the server

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -743,6 +743,12 @@ class SMBRelayServer(Thread):
 
                 # Return status code of the authentication process.
                 errorCode = self.returnStatus
+                errorCodeTxt = {
+                    STATUS_SUCCESS : 'STATUS_SUCCESS',
+                    STATUS_ACCESS_DENIED : 'STATUS_ACCESS_DENIED',
+                    STATUS_LOGON_FAILURE : 'STATUS_LOGON_FAILURE'
+                }[errorCode]
+                logging.info("Sending status code after authentication %s to the %s" % (errorCodeTxt, connData['ClientIP']))
 
                 respToken = SPNEGO_NegTokenResp()
                 # accept-completed
@@ -812,6 +818,12 @@ class SMBRelayServer(Thread):
             # Do the verification here, for just now we grant access
             # TODO: Manage more UIDs for the same session
             errorCode = self.returnStatus
+            errorCodeTxt = {
+                STATUS_SUCCESS : 'STATUS_SUCCESS',
+                STATUS_ACCESS_DENIED : 'STATUS_ACCESS_DENIED',
+                STATUS_LOGON_FAILURE : 'STATUS_LOGON_FAILURE'
+            }[errorCode]
+            logging.info("Sending status code after authentication %s to the %s" % (errorCodeTxt, connData['ClientIP']))
             connData['Uid'] = 10
             respParameters['Action'] = 0
 


### PR DESCRIPTION
There are some cases in which we may want to inform requesting client that the authentication failed for some reason. Such reason may be Access Denied when the client has been denied access to the ADMIN$ share - which in turn may let the client reconfigure his or target system (like for instance when Remote UAC was in use). Other reason might be Logon Failure - which in turn will make the client keep trying to authenticate with possibly other credentials and thus allowing us to collect more of them.

Not always we are comfortable with stating that the client has sent valid credentials and thus allowing him to store them in his LSA.

This PR implements functionality for such situation.