### PR TITLE
added extensibleMatch string filter parsing

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -42,7 +42,7 @@ except:
 
 # https://tools.ietf.org/search/rfc4515#section-3
 DESC = ur'(?:[a-z][a-z0-9\-]*)'
-NUM_OID = ur'(?:\d|[1-9]\d)(?:\.(?:\d|[1-9]\d+))*'
+NUM_OID = ur'(?:\d|[1-9]\d+)(?:\.(?:\d|[1-9]\d+))*'
 OID = ur'(?:{0}|{1})'.format(DESC, NUM_OID)
 OPTIONS = ur'(?:(?:;[a-z0-9\-]+)*)'
 ATTR = ur'({0}{1})'.format(OID, OPTIONS)


### PR DESCRIPTION
Must say you have motivated me to code this. I've checked with [here](https://github.com/CoreSecurity/impacket/blob/master/examples/GetUserSPNs.py#L218) and it seems to be working fine.

The 'not' filter is being built a bit differently in current code:
```
Filter:
 not=Not:
  notFilter=Filter:
   ...
```

vs old code:
```
Not:
 notFilter=Filter:
  ...
```

but it does not seem to make a difference. Testing would be appreciated.

Additionally, would be great if #190 is implemented ASAP. Really could use that functionality. I guess I could help.