### PR TITLE
 added simple paging support

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -360,24 +360,28 @@ class LDAPConnection:
         if receivedControls is not None:
             for receivedControl in receivedControls:
                 for requestedControl in requestedControls:
-                    if receivedControl['controlType'] == requestedControl['controlType']:
-                        done = done and self._handleControl(requestedControl, receivedControl)
+                    controlDone, controlHandled = self._handleControl(requestedControl, receivedControl)
+                    done = done and controlDone
+                    if controlHandled:
                         break
                 else:
-                    # ToDo: received unwanted control
+                    # ToDo: got an unhandeled control
                     pass
         return done
 
     def _handleControl(self, requestedControl, receivedControl):
         done = True
+        handled = False
         if requestedControl['controlType'] == CONTROL_PAGEDRESULTS:
-            if receivedControl.getCookie():
-                done = False
-            requestedControl.setCookie(receivedControl.getCookie())
+            if receivedControl['controlType'] == CONTROL_PAGEDRESULTS:
+                if receivedControl.getCookie():
+                    done = False
+                requestedControl.setCookie(receivedControl.getCookie())
+                handled = True
         else:
             # ToDo: handle different controls here
             pass
-        return done
+        return done, handled
 
     def close(self):
         if self._socket is not None:

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -528,7 +528,7 @@ class LDAPConnection:
             choice = MatchingRuleAssertion()
             if attribute:
                 choice.setComponentByName('type', attribute)
-            choice.setComponentByName('dnAttributes', bool(True))
+            choice.setComponentByName('dnAttributes', bool(dn))
             if matchingRule:
                 choice.setComponentByName('matchingRule', matchingRule)
             choice.setComponentByName('matchValue', value)

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -335,7 +335,7 @@ class LDAPConnection:
             searchRequest['attributes'].setComponents(*attributes)
 
         done = False
-        results = []
+        answers = []
         # We keep asking records until we get a searchResDone packet
         while not done:
             response = self.sendReceive('searchRequest', searchRequest, searchControls)
@@ -349,11 +349,11 @@ class LDAPConnection:
                                               errorString='Error in searchRequest -> %s:%s' % (
                                                   protocolOp['searchResDone']['resultCode'].prettyPrint(),
                                                   protocolOp['searchResDone']['diagnosticMessage']),
-                                              answers=results)
+                                              answers=answers)
                 else:
-                    results.append(message['protocolOp'][protocolOp.getName()])
+                    answers.append(message['protocolOp'][protocolOp.getName()])
 
-        return results  # ToDo: sorted(results) ?
+        return answers  # ToDo: sorted(answers) ?
 
     def _handleControls(self, requestControls, resultControls):
         done = True

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -29,7 +29,7 @@ from impacket import LOG
 from impacket.ldap.ldapasn1 import BindRequest, Integer7Bit, LDAPDN, AuthenticationChoice, AuthSimple, LDAPMessage, \
     SCOPE_SUB, SearchRequest, Scope, DEREF_NEVER, DeRefAliases, IntegerPositive, Boolean, AttributeSelection, \
     SaslCredentials, LDAPString, ProtocolOp, Credentials, Filter, SubstringFilter, Present, EqualityMatch, \
-    ApproxMatch, GreaterOrEqual, LessOrEqual, MatchingRuleAssertion, SubStrings, SubString, And, Or, Not, LDAPOID, \
+    ApproxMatch, GreaterOrEqual, LessOrEqual, MatchingRuleAssertion, SubStrings, SubString, And, Or, Not, \
     Controls, ResultCode, CONTROL_PAGEDRESULTS
 from impacket.ntlm import getNTLMSSPType1, getNTLMSSPType3
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -464,7 +464,7 @@ class LDAPConnection:
         filterStr = u''.join(filter)
         try:
             # https://tools.ietf.org/search/rfc4515#section-3
-            attribute, operator, value = re.split(RE_OPERATOR, filterStr, 1)
+            attribute, operator, value = RE_OPERATOR.split(filterStr, 1)
         except ValueError:
             raise LDAPFilterInvalidException("invalid filter: '({0})'".format(filterStr))
 
@@ -521,7 +521,7 @@ class LDAPConnection:
                     components.append(SubString().setComponentByName('initial', initial))
                 for assertion in assertions[1:-1]:
                     if not assertion:
-                        raise LDAPFilterInvalidException("consecutive '*' in filter")
+                        raise LDAPFilterInvalidException("consecutive '*' in filter assertion")
                     components.append(SubString().setComponentByName('any', assertion))
                 final = assertions[-1]
                 if final:

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -342,7 +342,6 @@ class LDAPConnection:
             for item in resp:
                 protocolOp = item['protocolOp']
                 if protocolOp.getName() == 'searchResDone':
-                    done = True
                     if protocolOp['searchResDone']['resultCode'] == ResultCode('success'):
                         done = self._handleControls(searchControls, item['controls'])
                     else:

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -339,7 +339,7 @@ class LDAPConnection:
         # We keep asking records until we get a searchResDone packet
         while not done:
             resp = self.sendReceive('searchRequest', searchRequest, searchControls)
-            for i, item in enumerate(resp):
+            for item in resp:
                 protocolOp = item['protocolOp']
                 if protocolOp.getName() == 'searchResDone':
                     done = True

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -362,7 +362,7 @@ class LDAPConnection:
             for receivedControl in receivedControls:
                 for requestedControl in requestedControls:
                     if receivedControl['controlType'] == requestedControl['controlType']:
-                        done = self._handleControl(requestedControl, receivedControl)
+                        done = done and self._handleControl(requestedControl, receivedControl)
                         break
                 else:
                     # ToDo: received unwanted control

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -363,7 +363,7 @@ class LDAPConnection:
                 for requestedControl in requestedControls:
                     if receivedControl['controlType'] == requestedControl['controlType']:
                         done = self._handleControl(requestedControl, receivedControl)
-                    break
+                        break
                 else:
                     # ToDo: received unwanted control
                     pass

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -807,7 +807,7 @@ class SimplePagedResultsControl(Control):
     def getCriticality(self):
         return self['criticality']
 
-    def setCriticality(self, value):
+    def setCritical(self, value):
         self['criticality'] = value
 
     def getSize(self):

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -831,7 +831,7 @@ KNOWN_CONTROLS[CONTROL_PAGEDRESULTS] = SimplePagedResultsControl
 
 class Controls(SequenceOf):
     # Controls ::= SEQUENCE OF Control
-    tagSet = SequenceOf.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatSimple, 0))
+    tagSet = SequenceOf.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatConstructed, 0))
     componentType = Control()
 
 


### PR DESCRIPTION
This implements #190 plus does some extra stuff.

The only thing that is different from not using paging is that SearchResultReference were always at the very end of whatever search() returned (after SearchResultEntry). With paging SearchResultReference will show up after the first page in results. It probably makes no difference, but this can be fixed as commented [here](https://github.com/CoreSecurity/impacket/pull/193/files#diff-f9bdf90057454cf2c4047d1d69e613beR356) if we want to.

without paging:
```
impacket.ldap.ldapasn1.SearchResultEntry
...
impacket.ldap.ldapasn1.SearchResultEntry
impacket.ldap.ldapasn1.SearchResultReference
impacket.ldap.ldapasn1.SearchResultReference
impacket.ldap.ldapasn1.SearchResultReference
```
page size = 1:
```
impacket.ldap.ldapasn1.SearchResultEntry
impacket.ldap.ldapasn1.SearchResultReference
impacket.ldap.ldapasn1.SearchResultReference
impacket.ldap.ldapasn1.SearchResultReference
impacket.ldap.ldapasn1.SearchResultEntry
...
impacket.ldap.ldapasn1.SearchResultEntry
```


I've removed manualFilter in the end as the parsing algorithm should handle all filters now. To transition just use a string filter in the searchFilter attribute.

This is how to use the new paging functionality:
```python
from impacket.ldap.ldap import LDAPConnection
from impacket.ldap.ldapasn1 import SimplePagedResultsControl

conn = LDAPConnection(url, baseDN)
conn.login(username, password)

sc = SimplePagedResultsControl(True, 5)  # defaults are (criticality=False, size=1000, cookie='')
resp = conn.search(searchFilter='(&(objectCategory=person)(objectClass=user))', attributes=['cn'], sizeLimit=10, esearchControls=[sc])

for item in resp:
    print item.prettyPrint()
```

Please test.

Thanks to @the-useless-one for starting this [here](https://github.com/CoreSecurity/impacket/commit/daaa39f982c83f6ebe292291b08dc1351016f5a1).