### PR TITLE
fix tagSet for approxMatch (#195)

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -539,8 +539,6 @@ class LDAPConnection:
                 if initial:
                     components.append(SubString().setComponentByName('initial', initial))
                 for assertion in assertions[1:-1]:
-                    if not assertion:
-                        raise LDAPFilterInvalidException("consecutive '*' in filter assertion")
                     components.append(SubString().setComponentByName('any', assertion))
                 final = assertions[-1]
                 if final:
@@ -561,6 +559,8 @@ class LDAPConnection:
                 elif operator == u'<=':
                     choice = LessOrEqual().setComponents(attribute, value)
                     searchFilter.setComponentByName('lessOrEqual', choice)
+            else:
+                raise LDAPFilterInvalidException("invalid filter '({0}{1}{2})'".format(attribute, operator, value))
 
         return searchFilter
 

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -23,7 +23,7 @@ import re
 from binascii import unhexlify
 
 from pyasn1.codec.ber import decoder, encoder
-from pyasn1.error import SubstrateUnderrunError, PyAsn1Error
+from pyasn1.error import SubstrateUnderrunError
 
 from impacket import LOG
 from impacket.ldap.ldapasn1 import BindRequest, Integer7Bit, LDAPDN, AuthenticationChoice, AuthSimple, LDAPMessage, \

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -853,7 +853,6 @@ class SimplePagedResultsControl(Control):
         self._cookie = value
         self._encodeControlValue()
 
-
 KNOWN_CONTROLS[CONTROL_PAGEDRESULTS] = SimplePagedResultsControl
 
 

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -21,7 +21,7 @@ from pyasn1.type.univ import Sequence, Integer, Choice, SequenceOf, OctetString,
 from pyasn1.type.constraint import ValueRangeConstraint, ValueSizeConstraint
 from pyasn1.type.namedtype import NamedType, DefaultedNamedType, OptionalNamedType, NamedTypes
 
-from pyasn1.type.tag import Tag, tagClassContext, tagFormatConstructed, tagClassApplication, tagFormatSimple
+from pyasn1.type.tag import Tag, tagClassApplication, tagClassContext, tagFormatSimple, tagFormatConstructed
 from pyasn1.type.namedval import NamedValues
 
 ################################################################################
@@ -155,6 +155,7 @@ class Referral(SequenceOf):
     """
     tagSet = SequenceOf.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatConstructed, 3))
     componentType = URI()
+    subtypeSpec = SequenceOf.subtypeSpec + ValueSizeConstraint(1, MAXINT)
 
 
 class ResultCode(Enumerated):
@@ -370,7 +371,7 @@ class Present(AttributeDescription):
 
 class ApproxMatch(AttributeValueAssertion):
     # approxMatch   [8] AttributeValueAssertion
-    tagSet = AttributeValueAssertion.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatConstructed, 7))
+    tagSet = AttributeValueAssertion.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatConstructed, 8))
 
 
 class AssertionValue(OctetString):
@@ -685,6 +686,39 @@ class SearchResultReference(SequenceOf):
     subtypeSpec = SequenceOf.subtypeSpec + ValueSizeConstraint(1, MAXINT)
 
 
+class LDAPOID(OctetString):
+    """
+        LDAPOID ::= OCTET STRING -- Constrained to <numericoid>
+                                 -- [RFC4512]
+    """
+    pass
+
+
+class ExtendedResponseName(LDAPOID):
+    tagSet = LDAPOID.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatSimple, 10))
+
+
+class ExtendedResponeValue(OctetString):
+    tagSet = OctetString.tagSet.tagImplicitly(Tag(tagClassContext, tagFormatSimple, 11))
+
+
+class ExtendedResponse(Sequence):
+    """
+        ExtendedResponse ::= [APPLICATION 24] SEQUENCE {
+            COMPONENTS OF LDAPResult,
+            responseName     [10] LDAPOID OPTIONAL,
+            response         [11] OCTET STRING OPTIONAL }
+    """
+    tagSet = Sequence.tagSet.tagImplicitly(Tag(tagClassApplication, tagFormatConstructed, 24))
+    componentType = NamedTypes(
+        NamedType('resultCode', ResultCode()),
+        NamedType('matchedDN', LDAPDN()),
+        NamedType('diagnosticMessage', LDAPString()),
+        OptionalNamedType('responseName', ExtendedResponseName()),
+        OptionalNamedType('responseValue', ExtendedResponeValue()),
+    )
+
+
 class ProtocolOp(Choice):
     """
         protocolOp      CHOICE {
@@ -719,15 +753,8 @@ class ProtocolOp(Choice):
         NamedType('searchResEntry', SearchResultEntry()),
         NamedType('searchResDone', SearchResultDone()),
         NamedType('searchResRef', SearchResultReference()),
+        NamedType('extendedResp', ExtendedResponse()),
     )
-
-
-class LDAPOID(OctetString):
-    """
-        LDAPOID ::= OCTET STRING -- Constrained to <numericoid>
-                                 -- [RFC4512]
-    """
-    pass
 
 
 class Control(Sequence):
@@ -802,7 +829,7 @@ class SimplePagedResultsControl(Control):
         self['controlValue'] = encoder.encode(SimplePagedSearchControlValue().setComponents(self._size, self._cookie))
 
     def _decodeControlValue(self):
-        self._size, self._cookie = decoder.decode(self['controlValue'], asn1Spec=SimplePagedSearchControlValue())[0]
+        (self._size, self._cookie), _ = decoder.decode(self['controlValue'], asn1Spec=SimplePagedSearchControlValue())
 
     def getCriticality(self):
         return self['criticality']
@@ -825,6 +852,7 @@ class SimplePagedResultsControl(Control):
     def setCookie(self, value):
         self._cookie = value
         self._encodeControlValue()
+
 
 KNOWN_CONTROLS[CONTROL_PAGEDRESULTS] = SimplePagedResultsControl
 
@@ -876,5 +904,8 @@ class LDAPMessage(Sequence):
     componentType = NamedTypes(
         NamedType('messageID', MessageID()),
         NamedType('protocolOp', ProtocolOp()),
-        OptionalNamedType('controls', Controls())
+        OptionalNamedType('controls', Controls()),
+        # fix AD nonconforming to RFC
+        OptionalNamedType('responseName', ExtendedResponseName()),
+        OptionalNamedType('responseValue', ExtendedResponeValue()),
     )


### PR DESCRIPTION
* add extendedResult to ldapasn1
* add fix for AD nonconformity with RFC4511
* fix filter parsing code to conform with RFC4515 in ldap.py
* implemented handling of unsolicited notifications