### PR TITLE
ntlmrelayx improvements

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -94,7 +94,6 @@ class MSSQLRelayClient(tds.MSSQL):
         self.sendTDS(TDS_SSPI, str(authenticateMessageBlob))
         tds = self.recvTDS()
         self.replies = self.parseReply(tds['Data'])
-        print repr(self.replies)
         if self.replies.has_key(TDS_LOGINACK_TOKEN):
             #Once we are here, there is a full connection and we can
             #do whatever the current user has rights to do

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -74,7 +74,7 @@ class SMBRelayServer(Thread):
         smbConfig.set('IPC$','read only','yes')
         smbConfig.set('IPC$','share type','3')
         smbConfig.set('IPC$','path','')
-
+        
         self.server = SMBSERVER(('0.0.0.0',445), config_parser = smbConfig)
         self.server.processConfigFile()
 
@@ -452,7 +452,7 @@ class SMBRelayServer(Thread):
             clientThread = self.config.attacks['HTTP'](self.config, client, self.authUser)
             clientThread.start()
         if self.target[0] == 'MSSQL':
-            clientThread = self.config.attacks['MSSQL'](self.config, client, self.command)
+            clientThread = self.config.attacks['MSSQL'](self.config, client)
             clientThread.start()
 
     def _start(self):

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -19,14 +19,24 @@ class NTLMRelayxConfig:
         self.domainIp = None
         self.machineAccount = None
         self.machineHashes = None
-        self.exeFile = None
-        self.command = None
         self.target = None
         self.mode = None
         self.redirecthost = None
         self.outputFile = None
         self.attacks = None
         self.lootdir = None
+        self.randomtargets = False
+
+        #SMB options
+        self.exeFile = None
+        self.command = None
+
+        #LDAP options
+        self.dumpdomain = True
+        self.addda = True
+
+        #MSSQL options
+        self.queries = []
 
     def setOutputFile(self,outputFile):
         self.outputFile = outputFile
@@ -56,3 +66,13 @@ class NTLMRelayxConfig:
         self.machineAccount = machineAccount
         self.machineHashes = machineHashes
         self.domainIp = domainIp
+
+    def setRandomTargets(self,randomtargets):
+        self.randomtargets = randomtargets
+
+    def setLDAPOptions(self,dumpdomain,addda):
+        self.dumpdomain = dumpdomain
+        self.addda = addda
+
+    def setMSSQLOptions(self,queries):
+        self.queries = queries

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -85,16 +85,30 @@ class TargetsProcessor():
             self.clients_targets[client] = set([target])
         #print self.clients_targets
 
-    def get_target(self,client):
+    def get_target(self,client,choose_random=False):
+        candidates = []
         try:
             targetlist = self.clients_targets[client]
         except KeyError:
             #Client is probably new
-            return self.targets[0]
+            if choose_random:
+                return random.choice(self.targets)
+            else:
+                return self.targets[0]
+
         for target in self.targets:
             #Check if the target is already in the target list
             if target not in targetlist:
-                return target
+                #If random, populate candidates
+                if choose_random:
+                    candidates.append(target)
+                else:
+                    return target
+
+        #If we arrive here and have multiple candidates, randomly select one
+        if len(candidates) > 0:
+            return random.choice(candidates)
+
         #We are here, which means all the targets are already exhausted by the client
         logging.info("All targets processed for client %s" % client)
         return random.choice(self.targets)


### PR DESCRIPTION
- Sorted and added more command line options, differentiating between arguments for different clients
- Added support for multiple MSSQL queries (--query)
- Added support for target randomization (-ra or --random)
- Fixed bug where targets would not advance to the next when connecting failed in the HTTP server
- Added missing HTTP->MSSQL attack logic