### PR TITLE
Added a -A to wmiexec.py option to load credentials from an smbclient/mount.cifs auth file

### DIFF
--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -258,6 +258,54 @@ class RemoteShell(cmd.Cmd):
         print self.__outputBuffer
         self.__outputBuffer = ''
 
+class AuthFileSyntaxError(Exception):
+    
+    '''raised by load_smbclient_auth_file if it encounters a syntax error
+    while loading the smbclient-style authentication file.'''
+
+    def __init__(self, path, lineno, reason):
+        self.path=path
+        self.lineno=lineno
+        self.reason=reason
+    
+    def __str__(self):
+        return 'Syntax error in auth file %s line %d: %s' % (
+            self.path, self.lineno, self.reason )
+
+def load_smbclient_auth_file(path):
+
+    '''Load credentials from an smbclient-style authentication file (used by
+    smbclient, mount.cifs and others).  returns (domain, username, password)
+    or raises AuthFileSyntaxError or any I/O exceptions.'''
+
+    lineno=0
+    domain=None
+    username=None
+    password=None
+    for line in open(path):
+        lineno+=1
+
+        line = line.strip()
+
+        if line.startswith('#') or line=='':
+            continue
+            
+        parts = line.split('=',1)
+        if len(parts) != 2:
+            raise AuthFileSyntaxError(path, lineno, 'No "=" present in line')
+        
+        (k,v) = (parts[0].strip(), parts[1].strip())
+        
+        if k=='username':
+            username=v
+        elif k=='password':
+            password=v
+        elif k=='domain':
+            domain=v
+        else:
+            raise AuthFileSyntaxError(path, lineno, 'Unknown option %s' % repr(k))
+            
+    return (domain, username, password)
 
 # Process command-line arguments.
 if __name__ == '__main__':
@@ -280,6 +328,7 @@ if __name__ == '__main__':
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication (128 or 256 bits)')
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If ommited it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-A', action="store", metavar = "authfile", help="smbclient/mount.cifs-style authentication file. See smbclient man page's -A option.")
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -307,6 +356,10 @@ if __name__ == '__main__':
         address = address.rpartition('@')[2]
 
     try:
+        if options.A is not None:
+            (domain, username, password) = load_smbclient_auth_file(options.A)
+            logging.debug('loaded smbclient auth file: domain=%s, username=%s, password=%s' % (repr(domain), repr(username), repr(password)))
+        
         if domain is None:
             domain = ''
 


### PR DESCRIPTION
This adds a -A command line option to load domain/username/password from a file of the same format used by smbclient, mount.cifs and other utilities. Example:

```
> cat authfile 
username = steve
# comment
password = asdf
domain = THOST

> smbclient '\\10.0.9.41\share' -A authfile
Domain=[THOST] OS=[Windows 7 Professional 7601 ....
smb: \> 

> ./wmiexec.py 10.0.9.41 -A authfile
Impacket v0.9.16-dev - Copyright 2002-2016 Core Security Technologies

[*] SMBv2.1 dialect used
[!] Launching semi-interactive shell - Careful what you execute
[!] Press help for extra shell commands
C:\>exit
```