### PR TITLE
Update ntlmrelayx.py to fix domain dump bug

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -201,9 +201,9 @@ class LDAPAttack(Thread):
         else:
             logging.info('User is not a Domain Admin')
             if not dumpedDomain and self.config.dumpdomain:
+                dumpedDomain = True
                 logging.info('Dumping domain info for first time')
                 domainDumper.domainDump()
-                dumpedDomain = True
 
 class HTTPAttack(Thread):
     def __init__(self, config, HTTPClient, username):


### PR DESCRIPTION
The boolean `dumpedDomain` was being assigned after the completion of a domain dump. This can take quite some time on a large domain, meaning that every time a new request is processed the domain dump starts again (until the first dump is finished). This minor tweak should fix that.