### PR TITLE
Small fixes for NTLMRelayX http client module

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -21,7 +21,7 @@ class HTTPRelayClient:
         self.target = target
         _, host, path = target.split(':')
         host = host[2:]
-        self.path = '/' + path.split('/')[1]
+        self.path = '/' + path.split('/', 1)[1]
         self.session = HTTPConnection(host)
         self.lastresult = None
 

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -12,6 +12,7 @@
 # HTTP(s) client for relaying NTLMSSP authentication to webservers
 #
 import logging
+import re
 from httplib import HTTPConnection, ResponseNotReady
 import base64
 
@@ -47,9 +48,10 @@ class HTTPRelayClient:
         res = self.session.getresponse()
         res.read()
         try:
-            serverChallenge = base64.b64decode(res.getheader('WWW-Authenticate')[5:])
+            serverChallengeBase64 = re.search('NTLM ([a-zA-Z0-9+/]+={0,2})', res.getheader('WWW-Authenticate')).group(1)
+            serverChallenge = base64.b64decode(serverChallengeBase64)
             return serverChallenge
-        except (IndexError, KeyError):
+        except (IndexError, KeyError, AttributeError):
             logging.error('No NTLM challenge returned from server')
 
     def sendAuth(self,authenticateMessageBlob, serverChallenge=None):


### PR DESCRIPTION
While using ntlmrelayx.py example script, I've faced two issues with HTTP relay client:

1. Targets with sub-folders (or in other words URLs with multiple "/") are truncated to single folder
2. If target URL allows multiple authentication possibilities (NTLM/Basic/Negotiate etc.) HTTPResponse.getheader('WWW-Authenticate') function returns headers concatenated by ", " thus it is impossible to extract valid base64 string.

Fix is small and don't introduce third-party dependencies.