### PR TITLE
Don't try to encode the LDAP filter if it's already in unicode

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -445,7 +445,10 @@ class LDAPConnection:
         return self.recv()
 
     def _parseFilter(self, filterStr):
-        filterList = list(reversed(unicode(filterStr)))
+        try:
+            filterList = list(reversed(unicode(filterStr)))
+        except UnicodeDecodeError:
+            filterList = list(reversed(filterStr))
         searchFilter = self._consumeCompositeFilter(filterList)
         if filterList:  # we have not consumed the whole filter string
             raise LDAPFilterSyntaxError("unexpected token: '%s'" % filterList[-1])


### PR DESCRIPTION
Hi @asolino,

we're having a problem when we wan't to make an LDAP request with a filter encoded in UTF8 (see [this issue](https://github.com/the-useless-one/pywerview/issues/19)).

The main problem is that if the `filterStr` is already encoded in UTF8 in [this line](https://github.com/CoreSecurity/impacket/blob/master/impacket/ldap/ldap.py#L448), the call to `unicode` will fail. This pull request should fix the problem.

Let me know if you have any questions!

Cheers,

Y