### PR TITLE
Little check for enabled/disabled users.

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1663,6 +1663,13 @@ class NTDSHashes:
             else:
                 userName = '%s' % record[self.NAME_TO_INTERNAL['sAMAccountName']]
 
+            # Enabled / disabled users
+            if record[self.NAME_TO_INTERNAL['userAccountControl']] is not None:
+                if '{0:08b}'.format(record[self.NAME_TO_INTERNAL['userAccountControl']])[-2:-1] == '1':
+                    userName += '(current-disabled)'
+                elif '{0:08b}'.format(record[self.NAME_TO_INTERNAL['userAccountControl']])[-2:-1] == '0':
+                    userName += '(current)'
+
             if record[self.NAME_TO_INTERNAL['pwdLastSet']] is not None:
                 pwdLastSet = self.__fileTimeToDateTime(record[self.NAME_TO_INTERNAL['pwdLastSet']])
             else:


### PR DESCRIPTION
Hello,

I have added a check to dissociate enabled from disabled users while dumping hashes with secretsdump.py.
My patch is based on : https://blogs.technet.microsoft.com/heyscriptingguy/2005/05/12/how-can-i-get-a-list-of-all-the-disabled-user-accounts-in-active-directory/

Shab4z