### PR TITLE
Replaced shebang with a virtualenv friendly one

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/ifmap.py
+++ b/examples/ifmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ifmap - scan for listening DCERPC interfaces
 
 Usage: ifmap.py hostname port

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2012-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/loopchain.py
+++ b/examples/loopchain.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import time
 
 from impacket.examples import logger

--- a/examples/mmcexec.py
+++ b/examples/mmcexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/mssqlinstance.py
+++ b/examples/mssqlinstance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/nmapAnswerMachine.py
+++ b/examples/nmapAnswerMachine.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import random
 
 import os_ident

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/opdump.py
+++ b/examples/opdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """opdump - scan for operations on a given DCERPC interface
 
 Usage: opdump.py hostname port interface version

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/ping6.py
+++ b/examples/ping6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under a slightly modified version

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies)
 #
 # This software is provided under under a slightly modified version

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under a slightly modified version

--- a/examples/services.py
+++ b/examples/services.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/smbtorture.py
+++ b/examples/smbtorture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/sniff.py
+++ b/examples/sniff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/sniffer.py
+++ b/examples/sniffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/split.py
+++ b/examples/split.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/uncrc32.py
+++ b/examples/uncrc32.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # based on:
 #
 #              Reversing CRC - Theory and Practice.

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/tcpshell.py
+++ b/impacket/examples/ntlmrelayx/utils/tcpshell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/mqtt.py
+++ b/impacket/mqtt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # $Id$
 
 import glob


### PR DESCRIPTION
Replaced all instances of `#!/usr/bin/python` with `#!/usr/bin/env python` so impacket's examples and scripts can be run inside a virtualenv without having to call python.