### PR TITLE
Secretsdump refactoring

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1162,6 +1162,7 @@ class LSASecrets(OfflineRegistry):
     class SECRET_TYPE:
         LSA = 0
         LSA_HASHED = 1
+        LSA_RAW = 2
 
     def __init__(self, securityFile, bootKey, remoteOps=None, isRemote=False,
                  perSecretCallback=lambda secretType, secret: _print_helper(secret)):
@@ -1393,6 +1394,7 @@ class LSASecrets(OfflineRegistry):
         if secret != '':
             printableSecret = secret
             self.__secretItems.append(secret)
+            self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, printableSecret)
         else:
             # Default print, hexdump
             printableSecret  = '%s:%s' % (name, hexlify(secretItem))
@@ -1401,8 +1403,7 @@ class LSASecrets(OfflineRegistry):
             # user will need to decide what to do.
             if self.__module__ == self.__perSecretCallback.__module__:
                 hexdump(secretItem)
-            
-        self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, printableSecret)
+            self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA_RAW, printableSecret)
 
     def dumpSecrets(self):
         if self.__securityFile is None:

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1171,7 +1171,6 @@ class LSASecrets(OfflineRegistry):
         self.__bootKey = bootKey
         self.__LSAKey = ''
         self.__NKLMKey = ''
-        self.__isRemote = isRemote
         self.__vistaStyle = True
         self.__cryptoCommon = CryptoCommon()
         self.__securityFile = securityFile
@@ -1345,7 +1344,7 @@ class LSASecrets(OfflineRegistry):
             else:
                 # We have to get the account the service
                 # runs under
-                if self.__isRemote is True:
+                if hasattr(self.__remoteOps, 'getServiceAccount'):
                     account = self.__remoteOps.getServiceAccount(name[4:])
                     if account is None:
                         secret = self.UNKNOWN_USER + ':'
@@ -1364,7 +1363,7 @@ class LSASecrets(OfflineRegistry):
                 pass
             else:
                 # We have to get the account this password is for
-                if self.__isRemote is True:
+                if hasattr(self.__remoteOps, 'getDefaultLoginAccount'):
                     account = self.__remoteOps.getDefaultLoginAccount()
                     if account is None:
                         secret = self.UNKNOWN_USER + ':'
@@ -1385,7 +1384,7 @@ class LSASecrets(OfflineRegistry):
             # compute MD4 of the secret.. yes.. that is the nthash? :-o
             md4 = MD4.new()
             md4.update(secretItem)
-            if self.__isRemote is True:
+            if hasattr(self.__remoteOps, 'getMachineNameAndDomain'):
                 machine, domain = self.__remoteOps.getMachineNameAndDomain()
                 secret = "%s\\%s$:%s:%s:::" % (domain, machine, hexlify(ntlm.LMOWFv1('','')), hexlify(md4.digest()))
             else:


### PR DESCRIPTION
With this refactor I've added some flexibility for `impacket/examples/secretsdump.py` external clients, keeping backward compatibility (let me know otherwise).

I hope it can be merged (with the needed adaptations) and thanks in advance!