### PR TITLE
Fix for ENCODED_STRING class to decode UTF-16 strings

### DIFF
--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -142,11 +142,16 @@ class ENCODED_STRING(Structure):
                     # Let's search for the end of the string
                     index = data[1:].find('\x00')
                     data  = data[:index+1+1]
+                    self.fromString(data)
                 else:
                     self.structure = self.tunicode
-                    index = data[1:].find('\x00\x00')
-                    data = data[:index+1+2]
-            self.fromString(data)
+                    # index = data[1:].find('\x00\x00')
+                    # data = data[:index+1+2]
+                    self.fromString(data)
+                    try:
+                        self['Character'] = self['Character'].decode('utf-16le')
+                    except UnicodeDecodeError:
+                        pass
         else:
             self.structure = self.tascii
             self.data = None


### PR DESCRIPTION
Fixes #277.

According to [MS-WMIO](https://msdn.microsoft.com/en-us/library/cc250923.aspx) if Encoded-String-Flag is set to 0x01 the sequence of characters that follows consists of UTF-16 characters.

Patch removes logic determining end-of-string for Unicode strings, as it introduces errors for strings ending with non-ASCII letters. Haven't tested this logic thoroughly. 