### PR TITLE
removed email=* filter, added objectCategory filter)

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -130,7 +130,7 @@ class GetADUsers:
                 raise
 
         # Building the search filter
-        searchFilter = "(&(sAMAccountName=*)(mail=*)"
+        searchFilter = "(&(sAMAccountName=*)(objectCategory=user)"
 
         if self.__requestUser is not None:
             searchFilter += '(sAMAccountName:=%s))' % self.__requestUser


### PR DESCRIPTION
In regards to #290 

Addresses AD domains where email isn't configured. Not sure how often it would come up in real life, but in my labs I don't bother.

