### PR TITLE
Add ability to enumerate Domain SIDs

### DIFF
--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -33,8 +33,8 @@ class LSALookupSid:
         445: {'bindstr': r'ncacn_np:%s[\pipe\lsarpc]', 'set_host': True},
         }
 
-    def __init__(self, username, password, domain, port = None,
-                 hashes = None, maxRid=4000):
+    def __init__(self, username='', password='', domain='', port = None,
+                 hashes = None, domain_users = False, maxRid=4000):
 
         self.__username = username
         self.__password = password
@@ -43,6 +43,7 @@ class LSALookupSid:
         self.__domain = domain
         self.__lmhash = ''
         self.__nthash = ''
+        self.__domain_users = domain_users
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -83,12 +84,16 @@ class LSALookupSid:
         #dce.set_max_fragment_size(32)
 
         dce.bind(lsat.MSRPC_UUID_LSAT)
+        
         resp = lsat.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
         policyHandle = resp['PolicyHandle']
 
-        resp = lsad.hLsarQueryInformationPolicy2(dce, policyHandle, lsad.POLICY_INFORMATION_CLASS.PolicyAccountDomainInformation)
-
-        domainSid = resp['PolicyInformation']['PolicyAccountDomainInfo']['DomainSid'].formatCanonical()
+        if self.__domain_users: # get the Domain SID
+            resp = lsad.hLsarQueryInformationPolicy2(dce, policyHandle, lsad.POLICY_INFORMATION_CLASS.PolicyPrimaryDomainInformation)
+            domainSid =  resp['PolicyInformation']['PolicyPrimaryDomainInfo']['Sid'].formatCanonical()
+        else: # Get the target host SID
+            resp = lsad.hLsarQueryInformationPolicy2(dce, policyHandle, lsad.POLICY_INFORMATION_CLASS.PolicyAccountDomainInformation)
+            domainSid = resp['PolicyInformation']['PolicyAccountDomainInfo']['DomainSid'].formatCanonical()
 
         soFar = 0
         SIMULTANEOUS = 1000
@@ -149,10 +154,12 @@ if __name__ == '__main__':
                        'NetBIOS name and you cannot resolve it')
     group.add_argument('-port', choices=['135', '139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
+    group.add_argument('-domain-users', action='store_true', help='Enumerate Domain users (will likely forward requests to the DC)')
 
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful when proxying through smbrelayx)')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -173,14 +180,14 @@ if __name__ == '__main__':
     if domain is None:
         domain = ''
 
-    if password == '' and username != '' and options.hashes is None:
+    if password == '' and username != '' and options.hashes is None and options.no_pass is False:
         from getpass import getpass
         password = getpass("Password:")
 
     if options.target_ip is None:
         options.target_ip = remoteName
 
-    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.maxRid)
+    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.domain_users, options.maxRid)
     try:
         lookup.dump(remoteName, options.target_ip)
     except:

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -34,7 +34,7 @@ class LSALookupSid:
         }
 
     def __init__(self, username='', password='', domain='', port = None,
-                 hashes = None, domain_users = False, maxRid=4000):
+                 hashes = None, domain_sids = False, maxRid=4000):
 
         self.__username = username
         self.__password = password
@@ -43,7 +43,7 @@ class LSALookupSid:
         self.__domain = domain
         self.__lmhash = ''
         self.__nthash = ''
-        self.__domain_users = domain_users
+        self.__domain_sids = domain_sids
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -88,7 +88,7 @@ class LSALookupSid:
         resp = lsat.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
         policyHandle = resp['PolicyHandle']
 
-        if self.__domain_users: # get the Domain SID
+        if self.__domain_sids: # get the Domain SID
             resp = lsad.hLsarQueryInformationPolicy2(dce, policyHandle, lsad.POLICY_INFORMATION_CLASS.PolicyPrimaryDomainInformation)
             domainSid =  resp['PolicyInformation']['PolicyPrimaryDomainInfo']['Sid'].formatCanonical()
         else: # Get the target host SID
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                        'NetBIOS name and you cannot resolve it')
     group.add_argument('-port', choices=['135', '139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
-    group.add_argument('-domain-users', action='store_true', help='Enumerate Domain users (will likely forward requests to the DC)')
+    group.add_argument('-domain-sids', action='store_true', help='Enumerate Domain SIDs (will likely forward requests to the DC)')
 
     group = parser.add_argument_group('authentication')
 
@@ -187,7 +187,7 @@ if __name__ == '__main__':
     if options.target_ip is None:
         options.target_ip = remoteName
 
-    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.domain_users, options.maxRid)
+    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.domain_sids, options.maxRid)
     try:
         lookup.dump(remoteName, options.target_ip)
     except:


### PR DESCRIPTION
Reference #293

It would be extremely handy to bruteforce SIDs through an unprivileged, relayed connection using smbrelayx's socks proxy.

I made some slight modifications to allow the `-no-pass` argument, as well as to specify whether to use the Domain SID as the base (`-domain-sids`)

Tested in one of my labs and it looks like it's working fine:

```
(IMP)root@kali:/opt/r_impacket/examples# proxychains python lookupsid.py -no-pass -domain-sids CSCOU/arizzo@10.9.122.13
ProxyChains-3.1 (http://proxychains.sf.net)
Impacket v0.9.16-dev - Copyright 2002-2017 Core Security Technologies

[*] Brute forcing SIDs at 10.9.122.13
[*] StringBinding ncacn_np:10.9.122.13[\pipe\lsarpc]
|S-chain|-<>-127.0.0.1:1080-<><>-10.9.122.13:445-<><>-OK
498: CSCOU\Enterprise Read-only Domain Controllers (SidTypeGroup)
500: CSCOU\Administrator (SidTypeUser)
501: CSCOU\Guest (SidTypeUser)
502: CSCOU\krbtgt (SidTypeUser)
512: CSCOU\Domain Admins (SidTypeGroup)
513: CSCOU\Domain Users (SidTypeGroup)
514: CSCOU\Domain Guests (SidTypeGroup)
515: CSCOU\Domain Computers (SidTypeGroup)
516: CSCOU\Domain Controllers (SidTypeGroup)
517: CSCOU\Cert Publishers (SidTypeAlias)
518: CSCOU\Schema Admins (SidTypeGroup)
519: CSCOU\Enterprise Admins (SidTypeGroup)
...etc...
``` 

And the original functionality is still present:

```
(IMP)root@kali:/opt/r_impacket/examples# python lookupsid.py CSCOU/arizzo@10.9.122.13
Impacket v0.9.16-dev - Copyright 2002-2017 Core Security Technologies

Password:
[*] Brute forcing SIDs at 10.9.122.13
[*] StringBinding ncacn_np:10.9.122.13[\pipe\lsarpc]
500: ordws02\Administrator (SidTypeUser)
501: ordws02\Guest (SidTypeUser)
513: ordws02\None (SidTypeGroup)
1000: ordws02\WinRMRemoteWMIUsers__ (SidTypeAlias)
1001: ordws02\temp (SidTypeUser)
1002: ordws02\HomeUsers (SidTypeAlias)
1003: ordws02\HomeGroupUser$ (SidTypeUser)
1004: ordws02\clarkthecub (SidTypeUser)
```

Let me know what you think!