### PR TITLE
MS-EVEN6 Partial Implementation

### DIFF
--- a/impacket/dcerpc/v5/eventlog.py
+++ b/impacket/dcerpc/v5/eventlog.py
@@ -1,0 +1,325 @@
+from impacket.dcerpc.v5.rpcrt import DCERPCException
+from impacket.dcerpc.v5.ndr import NDRCALL, NDRPOINTER, NDRUniConformantArray, NDRUniVaryingArray, NDRSTRUCT
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD, LPWSTR, ULONG, LARGE_INTEGER, GUID, \
+    BOOLEAN, ULARGE_INTEGER, WORD, BYTE
+from impacket import system_errors
+from impacket.uuid import uuidtup_to_bin
+
+MSRPC_UUID_EVENTLOG = uuidtup_to_bin(('F6BEAFF7-1E19-4FBB-9F8F-B89E2018337C', '1.0'))
+
+class DCERPCSessionError(DCERPCException):
+    def __init__(self, error_string=None, error_code=None, packet=None):
+        DCERPCException.__init__(self, error_string, error_code, packet)
+
+    def __str__(self):
+        key = self.error_code
+        if system_errors.ERROR_MESSAGES.has_key(key):
+            error_msg_short = system_errors.ERROR_MESSAGES[key][0]
+            error_msg_verbose = system_errors.ERROR_MESSAGES[key][1]
+            return 'EVENTLOG SessionError: code: 0x%x - %s - %s' % (self.error_code, error_msg_short, error_msg_verbose)
+        else:
+            return 'EVENTLOG SessionError: unknown error code: 0x%x' % self.error_code
+
+################################################################################
+# CONSTANTS
+################################################################################
+
+# Evt Path Flags
+EvtQueryChannelName = 0x00000001
+EvtQueryFilePath = 0x00000002
+EvtReadOldestToNewest = 0x00000100
+EvtReadNewestToOldest = 0x00000200
+
+################################################################################
+# STRUCTURES
+################################################################################
+
+class CONTEXT_HANDLE_LOG_HANDLE(NDRSTRUCT):
+    align = 1
+    structure = (
+        ('Data', '20s=""'),
+    )
+
+class PCONTEXT_HANDLE_LOG_HANDLE(NDRPOINTER):
+    referent = (
+        ('Data', CONTEXT_HANDLE_LOG_HANDLE),
+    )
+
+class CONTEXT_HANDLE_LOG_QUERY(NDRSTRUCT):
+    align = 1
+    structure = (
+        ('Data', '20s=""'),
+    )
+
+class PCONTEXT_HANDLE_LOG_QUERY(NDRPOINTER):
+    referent = (
+        ('Data', CONTEXT_HANDLE_LOG_QUERY),
+    )
+
+class LPPCONTEXT_HANDLE_LOG_QUERY(NDRPOINTER):
+    referent = (
+        ('Data', PCONTEXT_HANDLE_LOG_QUERY),
+    )
+
+class CONTEXT_HANDLE_OPERATION_CONTROL(NDRSTRUCT):
+    align = 1
+    structure = (
+        ('Data', '20s=""'),
+    )
+
+class PCONTEXT_HANDLE_OPERATION_CONTROL(NDRPOINTER):
+    referent = (
+        ('Data', CONTEXT_HANDLE_OPERATION_CONTROL),
+    )
+
+# 2.2.11 EvtRpcQueryChannelInfo
+class EvtRpcQueryChannelInfo(NDRSTRUCT):
+    structure = (
+        ('Name', LPWSTR),
+        ('Status', DWORD),
+    )
+
+class EvtRpcQueryChannelInfoArray(NDRUniVaryingArray):
+    item = EvtRpcQueryChannelInfo
+
+class LPEvtRpcQueryChannelInfoArray(NDRPOINTER):
+    referent = (
+        ('Data', EvtRpcQueryChannelInfoArray)
+    )
+
+class RPC_INFO(NDRSTRUCT):
+    structure = (
+        ('Error', DWORD),
+        ('SubError', DWORD),
+        ('SubErrorParam', DWORD),
+    )
+
+class PRPC_INFO(NDRPOINTER):
+    referent = (
+        ('Data', RPC_INFO)
+    )
+
+class WSTR_ARRAY(NDRUniVaryingArray):
+    item = WSTR
+
+class DWORD_ARRAY(NDRUniVaryingArray):
+    item = DWORD
+
+class LPDWORD_ARRAY(NDRPOINTER):
+    referent = (
+        ('Data', DWORD_ARRAY)
+    )
+
+class BYTE_ARRAY(NDRUniVaryingArray):
+    item = 'c'
+
+class CBYTE_ARRAY(NDRUniVaryingArray):
+    item = BYTE
+
+class CDWORD_ARRAY(NDRUniConformantArray):
+    item = DWORD
+
+class LPBYTE_ARRAY(NDRPOINTER):
+    referent = (
+        ('Data', CBYTE_ARRAY)
+    )
+
+class ULONG_ARRAY(NDRUniVaryingArray):
+    item = ULONG
+
+# 2.3.1 EVENT_DESCRIPTOR
+class EVENT_DESCRIPTOR(NDRSTRUCT):
+    structure = (
+        ('Id', WORD),
+        ('Version', BYTE),
+        ('Channel', BYTE),
+        ('LevelSeverity', BYTE),
+        ('Opcode', BYTE),
+        ('Task', WORD),
+        ('Keyword', ULONG),
+    )
+
+class BOOKMARK(NDRSTRUCT):
+    structure = (
+        ('BookmarkSize', DWORD),
+        ('HeaderSize', '<L=0x18'),
+        ('ChannelSize', DWORD),
+        ('CurrentChannel', DWORD),
+        ('ReadDirection', DWORD),
+        ('RecordIdsOffset', DWORD),
+        ('LogRecordNumbers', ULONG_ARRAY),
+    )
+
+
+#2.2.17 RESULT_SET
+class RESULT_SET(NDRSTRUCT):
+    structure = (
+        ('TotalSize', DWORD),
+        ('HeaderSize', DWORD),
+        ('EventOffset', DWORD),
+        ('BookmarkOffset', DWORD),
+        ('BinXmlSize', DWORD),
+        ('EventData', BYTE_ARRAY),
+        #('NumberOfSubqueryIDs', '<L=0'),
+        #('SubqueryIDs', BYTE_ARRAY),
+        #('BookMarkData', BOOKMARK),
+    )
+
+################################################################################
+# RPC CALLS
+################################################################################
+
+class EvtRpcRegisterLogQuery(NDRCALL):
+    opnum = 5
+    structure = (
+        ('Path', LPWSTR),
+        ('Query', WSTR),
+        ('Flags', DWORD),
+    )
+
+class EvtRpcRegisterLogQueryResponse(NDRCALL):
+    structure = (
+        ('Handle', CONTEXT_HANDLE_LOG_QUERY),
+        ('OpControl', CONTEXT_HANDLE_OPERATION_CONTROL),
+        ('QueryChannelInfoSize', DWORD),
+        ('QueryChannelInfo', EvtRpcQueryChannelInfoArray),
+        ('Error', RPC_INFO),
+        )
+
+class EvtRpcQueryNext(NDRCALL):
+    opnum = 11
+    structure = (
+        ('LogQuery', CONTEXT_HANDLE_LOG_QUERY),
+        ('NumRequestedRecords', DWORD),
+        ('TimeOutEnd', DWORD),
+        ('Flags', DWORD),
+    )
+
+class EvtRpcQueryNextResponse(NDRCALL):
+    structure = (
+        ('NumActualRecords', DWORD),
+        ('EventDataIndices', DWORD_ARRAY),
+        ('EventDataSizes', DWORD_ARRAY),
+        ('ResultBufferSize', DWORD),
+        ('ResultBuffer', BYTE_ARRAY),
+        ('ErrorCode', ULONG),
+    )
+
+class EvtRpcQuerySeek(NDRCALL):
+    opnum = 12
+    structure = (
+        ('LogQuery', CONTEXT_HANDLE_LOG_QUERY),
+        ('Pos', LARGE_INTEGER),
+        ('BookmarkXML', LPWSTR),
+        ('Flags', DWORD),
+    )
+
+class EvtRpcQuerySeekResponse(NDRCALL):
+    structure = (
+        ('Error', RPC_INFO),
+    )
+
+class EvtRpcClose(NDRCALL):
+    opnum = 13
+    structure = (
+        ("Handle", CONTEXT_HANDLE_LOG_HANDLE),
+    )
+
+class EvtRpcCloseResponse(NDRCALL):
+    structure = (
+        ("Handle", PCONTEXT_HANDLE_LOG_HANDLE),
+        ('ErrorCode', ULONG),
+    )
+
+class EvtRpcOpenLogHandle(NDRCALL):
+    opnum = 17
+    structure = (
+        ('Channel', WSTR),
+        ('Flags', DWORD),
+    )
+
+class EvtRpcOpenLogHandleResponse(NDRCALL):
+    structure = (
+        ('Handle', PCONTEXT_HANDLE_LOG_HANDLE),
+        ('Error', RPC_INFO),
+    )
+
+class EvtRpcGetChannelList(NDRCALL):
+    opnum = 19
+    structure = (
+        ('Flags', DWORD),
+    )
+
+class EvtRpcGetChannelListResponse(NDRCALL):
+    structure = (
+        ('NumChannelPaths', DWORD),
+        ('ChannelPaths', WSTR_ARRAY),
+        ('ErrorCode', ULONG),
+    )
+
+################################################################################
+# OPNUMs and their corresponding structures
+################################################################################
+
+OPNUMS = {
+    5   : (EvtRpcRegisterLogQuery, EvtRpcRegisterLogQueryResponse),
+    11  : (EvtRpcQueryNext,  EvtRpcQueryNextResponse),
+    12  : (EvtRpcQuerySeek, EvtRpcQuerySeekResponse),
+    13  : (EvtRpcClose, EvtRpcCloseResponse),
+    17  : (EvtRpcOpenLogHandle, EvtRpcOpenLogHandle),
+    19  : (EvtRpcGetChannelList, EvtRpcGetChannelListResponse),
+}
+
+################################################################################
+# HELPER FUNCTIONS
+################################################################################
+
+def hEvtRpcRegisterLogQuery(dce, path, flags, query='*\x00'):
+    request = EvtRpcRegisterLogQuery()
+
+    request['Path'] = path
+    request['Query'] = query
+    request['Flags'] = flags
+    resp = dce.request(request)
+    return resp
+
+def hEvtRpcQueryNext(dce, handle, numRequestedRecords, timeOutEnd=1000):
+    request = EvtRpcQueryNext()
+
+    request['LogQuery'] = handle
+    request['NumRequestedRecords'] = numRequestedRecords
+    request['TimeOutEnd'] = timeOutEnd
+    request['Flags'] = 0
+    status = system_errors.ERROR_MORE_DATA
+    resp = dce.request(request)
+    while status == system_errors.ERROR_MORE_DATA:
+        try:
+            resp = dce.request(request)
+        except DCERPCException, e:
+            if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
+                raise
+            elif str(e).find('ERROR_TIMEOUT') < 0:
+                raise
+            resp = e.get_packet()
+        return resp
+
+def hEvtRpcClose(dce, handle):
+    request = EvtRpcClose()
+    request['Handle'] = handle
+    resp = dce.request(request)
+    return resp
+
+def hEvtRpcOpenLogHandle(dce, channel, flags):
+    request = EvtRpcOpenLogHandle()
+
+    request['Channel'] = channel
+    request['Flags'] = flags
+    return dce.request(request)
+
+def hEvtRpcGetChannelList(dce):
+    request = EvtRpcGetChannelList()
+
+    request['Flags'] = 0
+    resp = dce.request(request)
+    return resp
+


### PR DESCRIPTION
Hi,

I implemented part of ms-even6 interface, my goal was to allow one to pull logs from remote machine so my main focus was on EvtRpcRegisterLogQuery, EvtRpcQueryNext and EvtRpcClose functions.
I did manage to get these to work, but I was having trouble implementing the BinXML parsing (EvtRpcQueryNext produce a byte array of BinXML format which is the actual event data).
So, it does work, but I was wondering if you can help with the parsing of the actual event, i.e. convert the byte array to the original xml format.

Below is the actual code of pulling events from a remote machine.

```
import eventlog
import hexdump
from eventlog import MSRPC_UUID_EVENTLOG
from lib.impacket.dcerpc.v5.dhcpm import MSRPC_UUID_DHCPSRV
from lib.impacket.dcerpc.v5 import transport
import logging
from socket import gethostbyaddr
import re
from limpacket.dcerpc.v5.epm import hept_map
from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE

class Connection(object):
    def __init__(self, target, username=str(), password=str(), domain=str(), krb=True):
        self.target, self.username, self.password, self.domain = target, username, password, domain,
        self.krb = krb
        if re.match('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', self.target):
            try:
                if gethostbyaddr(self.target)[0] == self.domain:
                    self.target = gethostbyaddr(self.target)[1][-1] + "." + self.domain
                else:
                    self.target = gethostbyaddr(self.target)[0]
            except:
                self.krb = False

class DCERPCConnection(Connection):
    binding_strings = dict()
    binding_strings['dhcpserver'] = MSRPC_UUID_DHCPSRV
    binding_strings['eventlog'] = MSRPC_UUID_EVENTLOG

    def __init__(self, target, pipe, username=str(), password=str(), domain=str(), krb=True):
        Connection.__init__(self, target=target, username=username, password=password, domain=domain,
                            krb=krb)
        self.pipe = pipe
        bind = self.binding_strings[self.pipe[1:]]
        self.string_binding = hept_map(self.target, bind, protocol='ncacn_ip_tcp')
        rpctransport = transport.DCERPCTransportFactory(self.string_binding)
        rpctransport.set_credentials(self.username, self.password, self.domain)
        self.dce = rpctransport.get_dce_rpc()
        if krb:
            rpctransport.set_kerberos(True, domain)
            self.dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)

connection = DCERPCConnection(<target>, '\eventlog', <username>, <password>, <domain>, False)
dce = connection.connect()
flags = eventlog.EvtQueryChannelName | eventlog.EvtReadNewestToLowest
resp = eventlog.hEvtRpcRegisterLogQuery(dce=dce, path=channel, flags=flags)
log_handle = resp['Handle']
ctrl_handle = resp['OpControl']
resp = eventlog.hEvtRpcQueryNext(dce, log_handle, 5)
for i in range(resp['NumActualRecords']):
    event_offset = resp['EventDataIndices'][i]['Data']
    event_size = resp['EventDataSizes'][i]['Data']
    event = resp['ResultBuffer'][event_offset:event_offset + event_size]
    buff = ''.join([x.encode('hex') for x in event]).decode('hex')
    print hexdump.hexdump(buff)

```