### PR TITLE
Bug fix: Make psexec service start manual. Add also a "-service-name" parameter where a user can name the service.

### DIFF
--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -55,7 +55,7 @@ lock = Lock()
 
 class PSEXEC:
     def __init__(self, command, path, exeFile, copyFile, port=445,
-                 username='', password='', domain='', hashes=None, aesKey=None, doKerberos=False, kdcHost=None):
+                 username='', password='', domain='', hashes=None, aesKey=None, doKerberos=False, kdcHost=None, serviceName=None):
         self.__username = username
         self.__password = password
         self.__port = port
@@ -69,6 +69,7 @@ class PSEXEC:
         self.__copyFile = copyFile
         self.__doKerberos = doKerberos
         self.__kdcHost = kdcHost
+        self.__serviceName = serviceName
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -129,7 +130,7 @@ class PSEXEC:
             # We don't wanna deal with timeouts from now on.
             s.setTimeout(100000)
             if self.__exeFile is None:
-                installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc())
+                installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc(), self.__serviceName)
             else:
                 try:
                     f = open(self.__exeFile)
@@ -442,6 +443,7 @@ if __name__ == '__main__':
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
+    group.add_argument('-service-name', action='store', metavar="service name", default = '', help='This will be the name of the service')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -482,5 +484,5 @@ if __name__ == '__main__':
         command = 'cmd.exe'
 
     executer = PSEXEC(command, options.path, options.file, options.c, int(options.port), username, password, domain, options.hashes,
-                      options.aesKey, options.k, options.dc_ip)
+                      options.aesKey, options.k, options.dc_ip, options.service_name)
     executer.run(remoteName, options.target_ip)

--- a/impacket/examples/serviceinstall.py
+++ b/impacket/examples/serviceinstall.py
@@ -23,9 +23,9 @@ from impacket.smbconnection import SMBConnection
 from impacket.smb3structs import FILE_WRITE_DATA, FILE_DIRECTORY_FILE
 
 class ServiceInstall:
-    def __init__(self, SMBObject, exeFile):
+    def __init__(self, SMBObject, exeFile, serviceName):
         self._rpctransport = 0
-        self.__service_name = ''.join([random.choice(string.letters) for i in range(4)])
+        self.__service_name = serviceName if len(serviceName) > 0  else  ''.join([random.choice(string.letters) for i in range(4)])
         self.__binary_service_name = ''.join([random.choice(string.letters) for i in range(8)]) + '.exe'
         self.__exeFile = exeFile
 
@@ -80,7 +80,7 @@ class ServiceInstall:
         command = '%s\\%s' % (path, self.__binary_service_name)
         try: 
             resp = scmr.hRCreateServiceW(self.rpcsvc, handle,self.__service_name + '\x00', self.__service_name + '\x00',
-                                         lpBinaryPathName=command + '\x00')
+                                         lpBinaryPathName=command + '\x00', dwStartType=scmr.SERVICE_DEMAND_START)
         except:
             LOG.critical("Error creating service %s on %s" % (self.__service_name, self.connection.getRemoteHost()))
             raise


### PR DESCRIPTION
Hi Alberto,

This pull request adds an enchanment and tries to fix one issue with the ```cmr.hRCreateServiceW()```
As mentioned <a href="https://github.com/byt3bl33d3r/CrackMapExec/pull/197">here</a>, smbexec would create an undesired persistence since the service would get launched automatically across system reboot.

However that fix does not apply for the psexec tool which I've been using extensively.
As a result, I had an incident where people were wondering why the service kept running after an X amount of time, which is really something that you want to avoid unless you want angry emails at 22:00 :)

The second part adds a simple enchanment where a user can provide a name for the service name using the ```-service-name``` parameter since there might be cases where we actually don't want to be sneaky. If one is not provided, it uses the default four digit random service.

Here's a nice screenshot depicting it:
<img width="970" alt="psexec_service_manual" src="https://user-images.githubusercontent.com/954127/30537845-4477428c-9c63-11e7-8299-4331f9696f62.png">


Please let me know your thoughts!