### PR TITLE
Trivial TypeError issue while LOG formatting

### DIFF
--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -127,7 +127,7 @@ class SMBConnection:
                 self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
                                                 self._sess_port, self._timeout, preferredDialect=preferredDialect)
             else:
-                LOG.critical("Unknown dialect ", preferredDialect)
+                LOG.critical("Unknown dialect %s", preferredDialect)
                 raise
 
         # propagate flags to the smb sub-object


### PR DESCRIPTION
We've identified this trivial issue while making some tests, which causes a `TypeError: not all arguments converted during string formatting` exception inside the Python's *logging* library.

It only occurs in an unlikely border case, when the user has selected an unsupported `preferredDialect` for the SMB connection. No functional scenarios are affected as an exception is going to be raised anyway (actually `None` is raised).