### PR TITLE
Add OldVal parameter dump to LSA secrets dump

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under a slightly modified version

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under a slightly modified version
@@ -165,7 +165,7 @@ class DumpSecrets:
                     else:
                         SECURITYFileName = self.__securityHive
 
-                    self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps, isRemote=self.__isRemote)
+                    self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps, isRemote=self.__isRemote, history=self.__history)
                     self.__LSASecrets.dumpCachedHashes()
                     if self.__outputFileName is not None:
                         self.__LSASecrets.exportCached(self.__outputFileName)
@@ -291,7 +291,7 @@ if __name__ == '__main__':
                        help='Shows pwdLastSet attribute for each NTDS.DIT account. Doesn\'t apply to -outputfile data')
     group.add_argument('-user-status', action='store_true', default=False,
                         help='Display whether or not the user is disabled')
-    group.add_argument('-history', action='store_true', help='Dump password history')
+    group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1222,7 +1222,7 @@ class LSASecrets(OfflineRegistry):
         LSA_HASHED = 1
         LSA_RAW = 2
 
-    def __init__(self, securityFile, bootKey, remoteOps=None, isRemote=False,
+    def __init__(self, securityFile, bootKey, remoteOps=None, isRemote=False, history=False,
                  perSecretCallback=lambda secretType, secret: _print_helper(secret)):
         OfflineRegistry.__init__(self, securityFile, isRemote)
         self.__hashedBootKey = ''
@@ -1236,6 +1236,7 @@ class LSASecrets(OfflineRegistry):
         self.__cachedItems = []
         self.__secretItems = []
         self.__perSecretCallback = perSecretCallback
+        self.__history = history
 
     def MD5(self, data):
         md5 = hashlib.new('md5')
@@ -1485,19 +1486,24 @@ class LSASecrets(OfflineRegistry):
 
         for key in keys:
             LOG.debug('Looking into %s' % key)
-            value = self.getValue('\\Policy\\Secrets\\%s\\CurrVal\\default' % key)
+            valueTypeList = ['CurrVal']
+            # Check if old LSA secrets values are also need to be shown
+            if self.__history:
+            	valueTypeList.append('OldVal')
 
-            if value is not None:
-                if self.__vistaStyle is True:
-                    record = LSA_SECRET(value[1])
-                    tmpKey = self.__sha256(self.__LSAKey, record['EncryptedData'][:32])
-                    plainText = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
-                    record = LSA_SECRET_BLOB(plainText)
-                    secret = record['Secret']
-                else:
-                    secret = self.__decryptSecret(self.__LSAKey, value[1])
-
-                self.__printSecret(key, secret)
+            for valueType in valueTypeList:
+                value = self.getValue('\\Policy\\Secrets\\{}\\{}\\default'.format(key,valueType))
+                if value is not None:
+                    if self.__vistaStyle is True:
+                        record = LSA_SECRET(value[1])
+                        tmpKey = self.__sha256(self.__LSAKey, record['EncryptedData'][:32])
+                        plainText = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
+                        record = LSA_SECRET_BLOB(plainText)
+                        secret = record['Secret']
+                    else:
+                        secret = self.__decryptSecret(self.__LSAKey, value[1])
+    
+                    self.__printSecret(key, secret)
 
     def exportSecrets(self, fileName):
         if len(self.__secretItems) > 0:


### PR DESCRIPTION
As it seen from source code
`value = self.getValue('\\Policy\\Secrets\\%s\\CurrVal\\default' % key)`
secretsdump.py dumps only current value of the LSAsecret. But there is a case when the current value is NULL but old value has a meaning. For example: DefaultPassword/OldVal can store actual password after the AutoLogon feature was disabled.