### PR TITLE
IPv6 compatibility and WPAD serving for MS16-077 bypass

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -432,12 +432,17 @@ if __name__ == '__main__':
                                                        'https://docs.python.org/2.4/lib/standard-encodings.html and then execute wmiexec.py '
                                                        'again with -codec and the corresponding codec ' % sys.getdefaultencoding())
     parser.add_argument('-smb2support', action="store_true", default=False, help='SMB2 Support (experimental!)')
-
+    parser.add_argument('-socks', action='store_true', default=False,
+                        help='Launch a SOCKS proxy for the connection relayed')
+    parser.add_argument('-wh','--wpad-host', action='store',help='Enable serving a WPAD file for Proxy Authentication attack, '
+                                                                   'setting the proxy host to the one supplied.')
+    parser.add_argument('-wa','--wpad-auth-num', action='store',help='Prompt for authentication N times for clients without MS16-077 installed '
+                                                                   'before serving a WPAD file.')
+    parser.add_argument('-6','--ipv6', action='store_true',help='Listen on both IPv6 and IPv4')
 
     #SMB arguments
     smboptions = parser.add_argument_group("SMB client options")
-    smboptions.add_argument('-socks', action='store_true', default=False,
-                        help='Launch a SOCKS proxy for the connection relayed')
+
     smboptions.add_argument('-e', action='store', required=False, metavar = 'FILE', help='File to execute on the target system. '
                                      'If not specified, hashes will be dumped (secretsdump.py must be in the same directory)')
     smboptions.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
@@ -535,6 +540,8 @@ if __name__ == '__main__':
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword,options.mailbox,options.all,options.imap_max)
+        c.setIPv6(options.ipv6)
+        c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
         c.setSMB2Support(options.smb2support)
 
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -58,7 +58,7 @@ class HTTPRelayClient(ProtocolClient):
             if 'NTLM' not in res.getheader('WWW-Authenticate'):
                 LOG.error('NTLM Auth not offered by URL, offered protocols: %s' % res.getheader('WWW-Authenticate'))
                 return False
-        except KeyError:
+        except (KeyError, TypeError):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)
             return False
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -23,6 +23,7 @@ import time
 import calendar
 import random
 import string
+import socket
 
 from binascii import hexlify
 from impacket import smb, ntlm, LOG, smb3
@@ -73,7 +74,12 @@ class SMBRelayServer(Thread):
         smbConfig.set('IPC$','share type','3')
         smbConfig.set('IPC$','path','')
 
-        self.server = SMBSERVER(('0.0.0.0',445), config_parser = smbConfig)
+        # Change address_family to IPv6 if this is configured
+        if self.config.ipv6:
+            SMBSERVER.address_family = socket.AF_INET6
+
+        self.server = SMBSERVER(('',445), config_parser = smbConfig)
+
         logging.getLogger('impacket.smbserver').setLevel(logging.CRITICAL)
         self.server.processConfigFile()
 

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -11,7 +11,7 @@
 #  Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
 #
 # Description:
-#     Configuration class which holds the config specified on the 
+#     Configuration class which holds the config specified on the
 # command line, this can be passed to the tools' servers and clients
 class NTLMRelayxConfig:
     def __init__(self):
@@ -27,6 +27,12 @@ class NTLMRelayxConfig:
         self.lootdir = None
         self.randomtargets = False
         self.encoding = None
+        self.ipv6 = False
+
+        #WPAD options
+        self.serve_wpad = False
+        self.wpad_host = None
+        self.wpad_auth_num = 0
         self.smb2support = False
 
         # SMB options
@@ -109,3 +115,12 @@ class NTLMRelayxConfig:
         self.mailbox = mailbox
         self.dump_all = dump_all
         self.dump_max = dump_max
+
+    def setIPv6(self, use_ipv6):
+        self.ipv6 = use_ipv6
+
+    def setWpadOptions(self, wpad_host, wpad_auth_num):
+        if wpad_host != None:
+            self.serve_wpad = True
+        self.wpad_host = wpad_host
+        self.wpad_auth_num = wpad_auth_num

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3517,7 +3517,8 @@ class Ioctls:
 class SMBSERVERHandler(SocketServer.BaseRequestHandler):
     def __init__(self, request, client_address, server, select_poll = False):
         self.__SMB = server
-        self.__ip, self.__port = client_address
+        # In case of AF_INET6 the client_address contains 4 items, ignore the last 2
+        self.__ip, self.__port = client_address[:2]
         self.__request = request
         self.__connId = threading.currentThread().getName()
         self.__timeOut = 60*5


### PR DESCRIPTION
- Added the ability to listen on IPv6 as well as IPv4
- Added option to serve a WPAD file
- Added automatic prompts for 407 Proxy-Authorization if a client attempts to use ntlmrelayx as a proxy