### PR TITLE
patching smbserver.py for ip specification

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -33,6 +33,7 @@ if __name__ == '__main__':
     parser.add_argument('sharePath', action='store', help='path of the share to add')
     parser.add_argument('-comment', action='store', help='share\'s comment to display when asked for shares')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ip', '--interface-address', action='store', default='0.0.0.0', help='ip address of listening interface')
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
 
     if len(sys.argv)==1:
@@ -55,7 +56,7 @@ if __name__ == '__main__':
     else:
         comment = options.comment
 
-    server = smbserver.SimpleSMBServer()
+    server = smbserver.SimpleSMBServer(listenAddress=options.interface_address)
 
     server.addShare(options.shareName.upper(), options.sharePath, comment)
     server.setSMB2Support(options.smb2support)


### PR DESCRIPTION
Name says it all. Added an argument for ip address specification with a default of 0.0.0.0. Tested fine on Debian Stretch (4.9.65-3+deb9u1) via interfaced alias.