### PR TITLE
Compatibility with ldap3==2.4.1, small bugfix in WPAD parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Python modules path; note that you might need special permissions to
 write there. For more information on what commands and options are
 available from setup.py, run `python setup.py --help-commands`.
 
+To install the dependencies for the examples, use either `pip install -r requirements_examples.txt` or use `pip install .[examples]` from the location you unpacked Impacket.
 
 Licensing
 =========

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -67,7 +67,7 @@ class LDAPRelayClient(ProtocolClient):
         #negoMessage['flags'] ^= NTLMSSP_NEGOTIATE_SIGN
         self.negotiateMessage = str(negoMessage)
 
-        with self.session.lock:
+        with self.session.connection_lock:
             if not self.session.sasl_in_progress:
                 self.session.sasl_in_progress = True
                 request = bind.bind_operation(self.session.version, 'SICILY_PACKAGE_DISCOVERY')
@@ -100,7 +100,7 @@ class LDAPRelayClient(ProtocolClient):
             token = respToken2['ResponseToken']
         else:
             token = authenticateMessageBlob
-        with self.session.lock:
+        with self.session.connection_lock:
             self.authenticateMessageBlob = token
             request = bind.bind_operation(self.session.version, 'SICILY_RESPONSE_NTLM', self, None)
             response = self.session.post_send_single_response(self.session.send('bindRequest', request, None))

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -83,12 +83,12 @@ class HTTPRelayServer(Thread):
             return SimpleHTTPServer.SimpleHTTPRequestHandler.send_error(self,code,message)
 
         def serve_wpad(self):
-            self.wpad = self.wpad % (self.server.config.wpad_host, self.server.config.wpad_host)
+            wpadResponse = self.wpad % (self.server.config.wpad_host, self.server.config.wpad_host)
             self.send_response(200)
             self.send_header('Content-type', 'application/x-ns-proxy-autoconfig')
-            self.send_header('Content-Length',len(self.wpad))
+            self.send_header('Content-Length',len(wpadResponse))
             self.end_headers()
-            self.wfile.write(self.wpad)
+            self.wfile.write(wpadResponse)
             return
 
         def should_serve_wpad(self, client):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyasn1>=0.2.3
+pycrypto>=2.6.1
+pyOpenSSL>=0.13.1

--- a/requirements_examples.txt
+++ b/requirements_examples.txt
@@ -1,0 +1,5 @@
+pyasn1>=0.2.3
+pycrypto>=2.6.1
+pyOpenSSL>=0.13.1
+ldap3==2.4.1
+ldapdomaindump

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import glob
 import os
 import platform
 
-from distutils.core import setup
+from setuptools import setup
 
 PACKAGE_NAME = "impacket"
 
@@ -35,4 +35,7 @@ setup(name = PACKAGE_NAME,
                     (os.path.join('share', 'doc', PACKAGE_NAME, 'testcases', 'ImpactPacket'),glob.glob('impacket/testcases/ImpactPacket/*')),
                     (os.path.join('share', 'doc', PACKAGE_NAME, 'testcases', 'SMB_RPC'),glob.glob('impacket/testcases/SMB_RPC/*'))],
       requires=setup_requires,
+      extras_require={
+                      'examples': ['ldapdomaindump', 'ldap3 (==2.4.1)']
+                    }
       )


### PR DESCRIPTION
- Connection `lock` property changed recently in ldap3
- Raises required ldap3 version for ntlmrelayx to 2.4.1 (this is the only version that works with the latest pyasn1 anyway)
- Fixed bug in WPAD parsing in which it would try to fill in variables multiple times