### PR TITLE
Wmiexec failures

### DIFF
--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -148,6 +148,7 @@ class RemoteShell(cmd.Cmd):
                 logging.error(str(e))
 
     def do_get(self, src_path):
+
         try:
             import ntpath
             newPath = ntpath.normpath(ntpath.join(self.__pwd, src_path))
@@ -157,10 +158,14 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\\%s" % (drive, tail))
             self.__transferClient.getFile(drive[:-1]+'$', tail, fh.write)
             fh.close()
+
         except Exception, e:
             logging.error(str(e))
-            os.remove(filename)
-            pass
+
+            if os.path.exists(filename):
+                os.remove(filename)
+
+
 
     def do_put(self, s):
         try:


### PR DESCRIPTION
This fixes wmiexec.py from crashing and exiting when there is an error while getting a file from the remote host. 