### PR TITLE
Replace socket.send() with socket.sendall()

### DIFF
--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -849,7 +849,7 @@ class NetBIOSTCPSession(NetBIOSSession):
         p = NetBIOSSessionPacket()
         p.set_type(NETBIOS_SESSION_MESSAGE)
         p.set_trailer(data)
-        self._sock.send(p.rawData())
+        self._sock.sendall(p.rawData())
 
     def recv_packet(self, timeout = None):
         data = self.__read(timeout)


### PR DESCRIPTION
While working with Impacket/smb and gevent (using monkey patching) I discovered an issue causing nmb.py to freeze while waiting for a response from the other peer. This issue happened due to the fact one of the calls to socket.send() did not verify that all the data was sent. This fix replaces the call to socket.send() with socket.sendall() which ensures all data was sent to the peer.

Note: It is possible that there are more calls to socket.send() that do not verify that all of the data was sent to the peer properly. The PR only fixes one specific call I had this trouble with.