### PR TITLE
Removing unnecessary shabangs

### DIFF
--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/__init__.py
+++ b/impacket/examples/ntlmrelayx/clients/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/imaprelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/clients/smtprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smtprelayclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/http.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/http.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/https.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/https.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/imap.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/imap.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/imaps.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/imaps.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2017 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/smtp.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/smtp.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/ssl.py
+++ b/impacket/examples/ntlmrelayx/utils/ssl.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/examples/ntlmrelayx/utils/tcpshell.py
+++ b/impacket/examples/ntlmrelayx/utils/tcpshell.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2013-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2003-2016 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version


### PR DESCRIPTION
Removing unnecessary shabangs for scripts which are meant to be modules
for including, but not for direct execution.
Related to the issue number #406 