### PR TITLE
Running flake8 will flag Python 3 incompatibilities

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 #envlist = py26#, py27,py36
-envlist = py27#,py36
+envlist = py27,py36
 [testenv]
 basepython =
     py26: python2.6
@@ -10,4 +10,6 @@ basepython =
 changedir = {toxinidir}/tests
 deps=-rrequirements.txt
     py26: wheel==0.29.0
-commands=./runall.sh {envname} > /dev/null
+commands=python -m pip install --upgrade flake8
+         python -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+         ./runall.sh {envname} > /dev/null


### PR DESCRIPTION
Even 12 undefined names in Python 2

@asolino Your review please?