### PR TITLE
Changed DCOM minor version

### DIFF
--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -167,7 +167,7 @@ class COMVERSION(NDRSTRUCT):
         NDRSTRUCT.__init__(self, data, isNDR64)
         if data is None:
             self['MajorVersion'] = 5
-            self['MinorVersion'] = 7
+            self['MinorVersion'] = 6
 
 class PCOMVERSION(NDRPOINTER):
     referent = (


### PR DESCRIPTION
Hi! 
I encountered the problem with wmiquery on Win2000 and WinXP SP1:
```
[-] RPC_E_VERSION_MISMATCH - The version of OLE on the client and server machines does not match.
Traceback (most recent call last):
  File "wmiquery.py", line 189, in <module>
    iWbemServices= iWbemLevel1Login.NTLMLogin(options.namespace, NULL, NULL)
  File "C:\Python27\lib\site-packages\impacket\dcerpc\v5\dcom\wmi.py", line 3093, in NTLMLogin
    resp = self.request(request, iid = self._iid, uuid = self.get_iPid())
  File "C:\Python27\lib\site-packages\impacket\dcerpc\v5\dcomrt.py", line 1310, in request
    resp = dce.request(req, uuid)
  File "C:\Python27\lib\site-packages\impacket\dcerpc\v5\rpcrt.py", line 837, in request
    answer = self.recv()
  File "C:\Python27\lib\site-packages\impacket\dcerpc\v5\rpcrt.py", line 1308, in recv
    raise DCERPCException('%s - %s' % (error_msg_short, error_msg_verbose))
DCERPCException: RPC_E_VERSION_MISMATCH - The version of OLE on the client and server machines does not match.
```
I also found that changing the minor version of DCOM solves this problem, and now wmi works fine on Win2000 and later