### PR TITLE
Bugfix in ticketer using "request" and "hashes" options

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -230,7 +230,7 @@ class TICKETER:
                 nthash = ''
             userName = Principal(self.__options.user, type=PrincipalNameType.NT_PRINCIPAL.value)
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
-                                                                    lmhash, nthash, None,
+                                                                    unhexlify(lmhash), unhexlify(nthash), None,
                                                                     self.__options.dc_ip)
             if self.__domain == self.__server:
                 kdcRep = decoder.decode(tgt, asn1Spec=AS_REP())[0]


### PR DESCRIPTION
When using _ticketer.py_ with the _-request_ and _-hashes_ options, a `ValueError` exception is raised because the NT hash length doesn't match with the expected value. This is because the NT hash is a hexadecimal string instead of binary data.