### PR TITLE
Use the global logger instance instead of a logger which is the root logger of the hierarchy

### DIFF
--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2730,7 +2730,7 @@ class IWbemClassObject(IRemUnknown):
                 #return self.__iWbemServices.ExecMethod('Win32_Process.Handle="436"', methodDefinition['name'],
                 #                                       pInParams=objRefCustomIn).getObject().ctCurrent['properties']
             except Exception, e:
-                if logging.getLogger().level == logging.DEBUG:
+                if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
                 LOG.error(str(e))

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -341,7 +341,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
                 LOG.debug('SOCKS: Connecting to %s(%s)' %(self.targetHost, self.targetPort))
                 s.connect((self.targetHost, self.targetPort))
             except Exception, e:
-                if logging.getLogger().level == logging.DEBUG:
+                if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
                 LOG.error('SOCKS: %s' %str(e))
@@ -367,7 +367,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
                     data = s.recv(8192)
                     self.__connSocket.sendall(data)
                 except Exception, e:
-                    if logging.getLogger().level == logging.DEBUG:
+                    if LOG.level == logging.DEBUG:
                         import traceback
                         traceback.print_exc()
                     LOG.error('SOCKS: ', str(e))
@@ -403,7 +403,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
 
                 relay.tunnelConnection()
             except Exception, e:
-                if logging.getLogger().level == logging.DEBUG:
+                if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
                 LOG.debug('SOCKS: %s' % str(e))

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -440,7 +440,7 @@ class RemoteOperations:
         request['pextClient']['cb'] = len(drs)
         request['pextClient']['rgb'] = list(str(drs))
         resp = self.__drsr.request(request)
-        if logging.getLogger().level == logging.DEBUG:
+        if LOG.level == logging.DEBUG:
             LOG.debug('DRSBind() answer')
             resp.dump()
 
@@ -455,7 +455,7 @@ class RemoteOperations:
 
         if drsExtensionsInt['dwReplEpoch'] != 0:
             # Different epoch, we have to call DRSBind again
-            if logging.getLogger().level == logging.DEBUG:
+            if LOG.level == logging.DEBUG:
                 LOG.debug("DC's dwReplEpoch != 0, setting it to %d and calling DRSBind again" % drsExtensionsInt[
                     'dwReplEpoch'])
             drs['dwReplEpoch'] = drsExtensionsInt['dwReplEpoch']
@@ -467,7 +467,7 @@ class RemoteOperations:
 
         # Now let's get the NtdsDsaObjectGuid UUID to use when querying NCChanges
         resp = drsuapi.hDRSDomainControllerInfo(self.__drsr, self.__hDrs, self.__domainName, 2)
-        if logging.getLogger().level == logging.DEBUG:
+        if LOG.level == logging.DEBUG:
             LOG.debug('DRSDomainControllerInfo() answer')
             resp.dump()
 
@@ -2235,7 +2235,7 @@ class NTDSHashes:
                             if self.__justNTLM is False:
                                 self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
                         except Exception, e:
-                            if logging.getLogger().level == logging.DEBUG:
+                            if LOG.level == logging.DEBUG:
                                 import traceback
                                 traceback.print_exc()
                             try:
@@ -2264,7 +2264,7 @@ class NTDSHashes:
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
                         except Exception, e:
-                            if logging.getLogger().level == logging.DEBUG:
+                            if LOG.level == logging.DEBUG:
                                 import traceback
                                 traceback.print_exc()
                             try:
@@ -2383,7 +2383,7 @@ class NTDSHashes:
                                         'pPrefixEntry'], keysOutputFile, clearTextOutputFile)
 
                             except Exception, e:
-                                if logging.getLogger().level == logging.DEBUG:
+                                if LOG.level == logging.DEBUG:
                                     import traceback
                                     traceback.print_exc()
                                 LOG.error("Error while processing user!")


### PR DESCRIPTION
Minor enhancement to use the global logger instance instead of a logger which is the root logger of the hierarchy.