### PR TITLE
Cross domain support

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -799,7 +799,7 @@ class MSSQL:
                 #         FQDN is the fully qualified domain name of the server.
                 #         port is the TCP port number.
                 #         instancename is the name of the SQL Server instance.
-                serverName = Principal('MSSQLSvc/%s.%s:%d' % (self.server.split('.')[0], domain, self.port), type=constants.PrincipalNameType.NT_SRV_INST.value)
+                serverName = Principal('MSSQLSvc/%s:%d' % (self.server, self.port), type=constants.PrincipalNameType.NT_SRV_INST.value)
                 try:
                     tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
                 except KerberosError, e:


### PR DESCRIPTION
Hi,
While using tds to connect to a sql server on a different domain, I encounter an issue. The scenario was as follows:
I was using a user account registered on "example.com" domain, and tried to login a sql server registered on a child domain "other.example.com". Using a TGT which I created with the appropriated permissions, I got a "principal not found" error.  Looking at tds.py, I noticed it presumes the server is registered on the same domain as the user account used for the login, so it failed to find its SPN.
In my scenario the SPN was MSSQLSvc/ServerName:1433, in contract to what MSDN says (FQDN).
Furthermore, I can see lines 740 and 721 needs a revision too, but I'm not sure if removing the @domain might cause other issues.
WDYT?