### PR TITLE
Fix ntlmrelayx encoding

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -82,13 +82,13 @@ class SMBAttack(ProtocolAttack):
             except Exception, e:
                 if "rpc_s_access_denied" in str(e): # user doesn't have correct privileges
                     if self.config.enumLocalAdmins:
-                        LOG.info("Relayed user doesn't have admin on {}. Attempting to enumerate users who do...".format(self.__SMBConnection.getRemoteHost()))
+                        LOG.info(u"Relayed user doesn't have admin on {}. Attempting to enumerate users who do...".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
                         enumLocalAdmins = EnumLocalAdmins(self.__SMBConnection)
                         try:
                             localAdminSids, localAdminNames = enumLocalAdmins.getLocalAdmins()
-                            LOG.info("Host {} has the following local admins (hint: try relaying one of them here...)".format(self.__SMBConnection.getRemoteHost()))
+                            LOG.info(u"Host {} has the following local admins (hint: try relaying one of them here...)".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
                             for name in localAdminNames:
-                                LOG.info("Host {} local admin member: {} ".format(self.__SMBConnection.getRemoteHost(), name))
+                                LOG.info(u"Host {} local admin member: {} ".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding), name))
                         except DCERPCException, e:
                             LOG.info("SAMR access denied")
                         return

--- a/impacket/examples/ntlmrelayx/utils/enum.py
+++ b/impacket/examples/ntlmrelayx/utils/enum.py
@@ -65,6 +65,6 @@ class EnumLocalAdmins:
         resp = lsat.hLsarLookupSids(dce, policyHandle, sids, lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
         names = []
         for n, item in enumerate(resp['TranslatedNames']['Names']):
-            names.append("{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'], item['Name']))
+            names.append(u"{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'].encode('utf-16-le'), item['Name']))
         dce.disconnect()
         return names

--- a/impacket/examples/ntlmrelayx/utils/enum.py
+++ b/impacket/examples/ntlmrelayx/utils/enum.py
@@ -44,11 +44,7 @@ class EnumLocalAdmins:
         resp = samr.hSamrLookupDomainInSamServer(dce, serverHandle, 'Builtin')
         resp = samr.hSamrOpenDomain(dce, serverHandle=serverHandle, domainId=resp['DomainId'])
         domainHandle = resp['DomainHandle']
-        resp = samr.hSamrEnumerateAliasesInDomain(dce, domainHandle)
-        aliases = {}
-        for alias in resp['Buffer']['Buffer']:
-            aliases[alias['Name']] =  alias['RelativeId']
-        resp = samr.hSamrOpenAlias(dce, domainHandle, desiredAccess=MAXIMUM_ALLOWED, aliasId=aliases['Administrators'])
+        resp = samr.hSamrOpenAlias(dce, domainHandle, desiredAccess=MAXIMUM_ALLOWED, aliasId=544)
         resp = samr.hSamrGetMembersInAlias(dce, resp['AliasHandle'])
         memberSids = []
         for member in resp['Members']['Sids']:


### PR DESCRIPTION
This fix two errors:
  - integrated administrators group name may vary depending on OS locale, causing this error (KeyError: 'Administrators')
  - user names may use non ascii characters (Invité is Guest in French for instance), causing this error when displaying on screen (UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019'...)