### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1051,7 +1051,7 @@ if __name__ == '__main__':
     from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, \
         SE_GROUP_ENABLED, USER_NORMAL_ACCOUNT, USER_DONT_EXPIRE_PASSWORD
     from pyasn1.codec.der import decoder, encoder
-    from Crypto.Hash import MD5
+    from Cryptodome.Hash import MD5
 
     print version.BANNER
 

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -27,7 +27,7 @@ from impacket.dcerpc.v5.transport import DCERPCTransportFactory
 from impacket.examples import logger
 
 try:
-    from Crypto.Cipher import ARC4
+    from Cryptodome.Cipher import ARC4
 except Exception:
     logging.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     logging.critical("See http://www.pycrypto.org/")

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -277,7 +277,7 @@ if __name__ == '__main__':
     import sys
     import logging
     from binascii import a2b_hex
-    from Crypto.Cipher import ARC4
+    from Cryptodome.Cipher import ARC4
     from impacket import ntlm, version
     try:
         import OpenSSL

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -71,7 +71,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile, SMBSER
 from impacket.spnego import ASN1_AID, SPNEGO_NegTokenResp, SPNEGO_NegTokenInit
 
 try:
- from Crypto.Cipher import DES, AES, ARC4
+ from Cryptodome.Cipher import DES, AES, ARC4
 except Exception:
     logging.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     logging.critical("See http://www.pycrypto.org/")

--- a/impacket/crypto.py
+++ b/impacket/crypto.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 from impacket import LOG
 try:
-    from Crypto.Cipher import DES, AES, ARC4
+    from Cryptodome.Cipher import DES, AES, ARC4
 except Exception:
     LOG.error("Warning: You don't have any crypto installed. You need PyCrypto")
     LOG.error("See http://www.pycrypto.org/")
@@ -54,7 +54,7 @@ def Generate_Subkey(K):
 #   +                                                                   +
 #   +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-    AES_128 = AES.new(K)
+    AES_128 = AES.new(K, AES.MODE_ECB)
 
     L = AES_128.encrypt('\x00'*16)
 
@@ -140,7 +140,7 @@ def AES_CMAC(K, M, length):
     const_Bsize = 16
     const_Zero  = '\x00'*16
 
-    AES_128= AES.new(K)
+    AES_128= AES.new(K, AES.MODE_ECB)
     M      = M[:length]
     K1, K2 = Generate_Subkey(K)
     n      = len(M)//const_Bsize
@@ -200,7 +200,7 @@ def AES_CMAC_PRF_128(VK, M, VKlen, Mlen):
         K = AES_CMAC('\x00'*16, VK, VKlen)
 
     PRV = AES_CMAC(K, M, Mlen)
- 
+
     return PRV
 
 def KDF_CounterMode(KI, Label, Context, L):
@@ -220,7 +220,7 @@ def KDF_CounterMode(KI, Label, Context, L):
 #  5. Return: KO := the leftmost L bits of result(n).
     h = 256
     r = 32
-    
+
     n = L // h
 
     if n == 0:
@@ -234,9 +234,9 @@ def KDF_CounterMode(KI, Label, Context, L):
 
     for i in range(1,n+1):
        input = pack('>L', i) + Label + '\x00' + Context + pack('>L',L)
-       K = hmac.new(KI, input, hashlib.sha256).digest() 
+       K = hmac.new(KI, input, hashlib.sha256).digest()
        result = result + K
- 
+
     return result[:(L//8)]
 
 # [MS-LSAD] Section 5.1.2 / 5.1.3
@@ -274,7 +274,7 @@ def decryptSecret(key, value):
         tmpStrKey = key0[:7]
         tmpKey = transformKey(tmpStrKey)
         Crypt1 = DES.new(tmpKey, DES.MODE_ECB)
-        plainText += Crypt1.decrypt(cipherText) 
+        plainText += Crypt1.decrypt(cipherText)
         cipherText = cipherText[8:]
         key0 = key0[7:]
         value = value[8:]
@@ -298,7 +298,7 @@ def encryptSecret(key, value):
         tmpStrKey = key0[:7]
         tmpKey = transformKey(tmpStrKey)
         Crypt1 = DES.new(tmpKey, DES.MODE_ECB)
-        cipherText += Crypt1.encrypt(plainText) 
+        cipherText += Crypt1.encrypt(plainText)
         plainText = plainText[8:]
         key0 = key0[7:]
         value0 = value0[8:]
@@ -324,7 +324,7 @@ def SamDecryptNTLMHash(encryptedHash, key):
     plain1 = Crypt1.decrypt(Block1)
     plain2 = Crypt2.decrypt(Block2)
 
-    return plain1 + plain2 
+    return plain1 + plain2
 
 def SamEncryptNTLMHash(encryptedHash, key):
     # [MS-SAMR] Section 2.2.11.1.1
@@ -342,7 +342,7 @@ def SamEncryptNTLMHash(encryptedHash, key):
     plain1 = Crypt1.encrypt(Block1)
     plain2 = Crypt2.encrypt(Block2)
 
-    return plain1 + plain2 
+    return plain1 + plain2
 
 
 
@@ -389,7 +389,7 @@ if __name__ == '__main__':
 
         print()
         return ''
-    
+
     from binascii import hexlify, unhexlify
 
     K = "2b7e151628aed2a6abf7158809cf4f3c"
@@ -404,19 +404,19 @@ if __name__ == '__main__':
     print("Example 1: len = 0")
     print("M                <empty string>")
     pp("AES-CMAC        " , (hexlify(AES_CMAC(unhexlify(K),unhexlify(M),0))))
-    print() 
+    print()
     print("Example 2: len = 16")
     pp("M               " , (M[:16*2]))
     pp("AES-CMAC        " , (hexlify(AES_CMAC(unhexlify(K),unhexlify(M),16))))
-    print() 
+    print()
     print("Example 3: len = 40")
     pp("M               " , (M[:40*2]))
     pp("AES-CMAC        " , (hexlify(AES_CMAC(unhexlify(K),unhexlify(M),40))))
-    print() 
+    print()
     print("Example 3: len = 64")
     pp("M               " , (M[:64*2]))
     pp("AES-CMAC        " , (hexlify(AES_CMAC(unhexlify(K),unhexlify(M),64))))
-    print() 
+    print()
     M = "eeab9ac8fb19cb012849536168b5d6c7a5e6c5b2fcdc32bc29b0e3654078a5129f6be2562046766f93eebf146b"
     K = "6c3473624099e17ff3a39ff6bdf6cc38"
     # Mac = dbf63fd93c4296609e2d66bf79251cb5
@@ -453,19 +453,19 @@ if __name__ == '__main__':
     print()
     print("Example 1: len = 0")
     pp("M               " , (K))
-    print("Key Length       18 ")  
+    print("Key Length       18 ")
     pp("AES-CMAC        " , (hexlify(AES_CMAC_PRF_128(unhexlify(K),unhexlify(M),18,len(unhexlify(M))))))
-    print() 
+    print()
     print("Example 1: len = 0")
     pp("M               " , (K))
-    print("Key Length       16 ")  
+    print("Key Length       16 ")
     pp("AES-CMAC        " , (hexlify(AES_CMAC_PRF_128(unhexlify(K)[:16],unhexlify(M),16,len(unhexlify(M))))))
-    print() 
+    print()
     print("Example 1: len = 0")
     pp("M               " , (K))
     print("Key Length       10 ")
     pp("AES-CMAC        " , (hexlify(AES_CMAC_PRF_128(unhexlify(K)[:10],unhexlify(M),10,len(unhexlify(M))))))
-    print() 
+    print()
 
 
 

--- a/impacket/dcerpc/v5/drsuapi.py
+++ b/impacket/dcerpc/v5/drsuapi.py
@@ -34,7 +34,7 @@ from pyasn1.type import univ
 from pyasn1.codec.ber import decoder
 
 try:
-    from Crypto.Cipher import ARC4, DES
+    from Cryptodome.Cipher import ARC4, DES
 except Exception:
     LOG.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     LOG.critical("See http://www.pycrypto.org/")

--- a/impacket/dcerpc/v5/nrpc.py
+++ b/impacket/dcerpc/v5/nrpc.py
@@ -33,7 +33,7 @@ from impacket.structure import Structure
 from impacket import ntlm, crypto, LOG
 import hmac, hashlib
 try:
-    from Crypto.Cipher import DES, AES, ARC4
+    from Cryptodome.Cipher import DES, AES, ARC4
 except Exception:
     LOG.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     LOG.critical("See http://www.pycrypto.org/")

--- a/impacket/dcerpc/v5/rpcrt.py
+++ b/impacket/dcerpc/v5/rpcrt.py
@@ -21,7 +21,7 @@ import logging
 import socket
 import sys
 from binascii import unhexlify
-from Crypto.Cipher import ARC4
+from Cryptodome.Cipher import ARC4
 
 from impacket import ntlm, LOG
 from impacket.structure import Structure,pack,unpack

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2754,7 +2754,7 @@ def hSamrUnicodeChangePasswordUser2(dce, serverName='\x00', userName='', oldPass
     request['UserName'] = userName
 
     try:
-        from Crypto.Cipher import ARC4
+        from Cryptodome.Cipher import ARC4
     except Exception:
         LOG.critical("Warning: You don't have any crypto installed. You need PyCrypto")
         LOG.critical("See http://www.pycrypto.org/")

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -74,8 +74,8 @@ from impacket.structure import Structure
 from impacket.winregistry import hexdump
 from impacket.uuid import string_to_bin
 try:
-    from Crypto.Cipher import DES, ARC4, AES
-    from Crypto.Hash import HMAC, MD4
+    from Cryptodome.Cipher import DES, ARC4, AES
+    from Cryptodome.Hash import HMAC, MD4
 except ImportError:
     LOG.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     LOG.critical("See http://www.pycrypto.org/")

--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -45,14 +45,14 @@ from binascii import unhexlify
 import string
 import random
 
-from Crypto.Util.number import GCD as gcd
-from Crypto.Cipher import AES, DES3, ARC4, DES
-from Crypto.Hash import HMAC, MD4, MD5, SHA
-from Crypto.Protocol.KDF import PBKDF2
+from Cryptodome.Util.number import GCD as gcd
+from Cryptodome.Cipher import AES, DES3, ARC4, DES
+from Cryptodome.Hash import HMAC, MD4, MD5, SHA
+from Cryptodome.Protocol.KDF import PBKDF2
 
 
 def get_random_bytes(lenBytes):
-    # We don't really need super strong randomness here to use PyCrypto.Random
+    # We don't really need super strong randomness here to use PyCryptodome.Random
     return "".join([random.choice(string.digits+string.letters) for i in xrange(lenBytes)])
 
 

--- a/impacket/krb5/gssapi.py
+++ b/impacket/krb5/gssapi.py
@@ -16,8 +16,8 @@ import struct
 import random
 import string
 
-from Crypto.Hash import HMAC, MD5
-from Crypto.Cipher import ARC4
+from Cryptodome.Hash import HMAC, MD5
+from Cryptodome.Cipher import ARC4
 
 from impacket.structure import Structure
 from impacket.krb5 import constants, crypto

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -39,9 +39,9 @@ def computeResponse(flags, serverChallenge, clientChallenge, serverName, domain,
         return computeResponseNTLMv1(flags, serverChallenge, clientChallenge, serverName, domain, user, password,
                                      lmhash, nthash, use_ntlmv2=use_ntlmv2)
 try:
-    from Crypto.Cipher import ARC4
-    from Crypto.Cipher import DES
-    from Crypto.Hash import MD4
+    from Cryptodome.Cipher import ARC4
+    from Cryptodome.Cipher import DES
+    from Cryptodome.Hash import MD4
 except Exception:
     LOG.critical("Warning: You don't have any crypto installed. You need PyCrypto")
     LOG.critical("See http://www.pycrypto.org/")

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -367,7 +367,7 @@ class SMB3:
             transformHeader['OriginalMessageSize'] = len(plainText)
             transformHeader['EncryptionAlgorithm'] = SMB2_ENCRYPTION_AES128_CCM
             transformHeader['SessionID'] = self._Session['SessionID'] 
-            from Crypto.Cipher import AES
+            from Cryptodome.Cipher import AES
             try: 
                 AES.MODE_CCM
             except:
@@ -392,7 +392,7 @@ class SMB3:
         if data.get_trailer().startswith('\xfdSMB'):
             # Packet is encrypted
             transformHeader = SMB2_TRANSFORM_HEADER(data.get_trailer())
-            from Crypto.Cipher import AES
+            from Cryptodome.Cipher import AES
             try: 
                 AES.MODE_CCM
             except:
@@ -419,7 +419,7 @@ class SMB3:
                 else:
                     # Packet is encrypted
                     transformHeader = SMB2_TRANSFORM_HEADER(data.get_trailer())
-                    from Crypto.Cipher import AES
+                    from Cryptodome.Cipher import AES
                     try: 
                         AES.MODE_CCM
                     except:
@@ -665,7 +665,7 @@ class SMB3:
                 self._Session['SigningActivated'] = True
             if self._Connection['Dialect'] == SMB2_DIALECT_30:
                 # SMB 3.0. Encryption should be available. Let's enforce it if we have AES CCM available
-                from Crypto.Cipher import AES
+                from Cryptodome.Cipher import AES
                 try:
                     AES.MODE_CCM
                     self._Session['SessionFlags'] |= SMB2_SESSION_FLAG_ENCRYPT_DATA
@@ -815,7 +815,7 @@ class SMB3:
                         self._Session['SigningActivated'] = True
                     if self._Connection['Dialect'] == SMB2_DIALECT_30:
                         # SMB 3.0. Encryption should be available. Let's enforce it if we have AES CCM available
-                        from Crypto.Cipher import AES
+                        from Cryptodome.Cipher import AES
                         try:
                             AES.MODE_CCM
                             self._Session['SessionFlags'] |= SMB2_SESSION_FLAG_ENCRYPT_DATA

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyasn1>=0.2.3
-pycrypto>=2.6.1
+pycryptodomex
 pyOpenSSL>=0.16.2
 ldap3>=2.5
 ldapdomaindump

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name = PACKAGE_NAME,
                 'impacket.examples.ntlmrelayx.attacks'],
       scripts = glob.glob(os.path.join('examples', '*.py')),
       data_files = data_files,
-      install_requires=['pyasn1>=0.2.3', 'pycrypto>=2.6.1', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump', 'flask'],
+      install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump', 'flask'],
       extras_require={
                       'pyreadline:sys_platform=="win32"': [],
                       ':python_version<"2.7"': [ 'argparse' ],

--- a/tests/SMB_RPC/test_mimilib.py
+++ b/tests/SMB_RPC/test_mimilib.py
@@ -75,7 +75,7 @@ class RRPTests(unittest.TestCase):
 
     def test_MimiCommand(self):
         dce, rpctransport, pHandle, key = self.connect()
-        from Crypto.Cipher import ARC4
+        from Cryptodome.Cipher import ARC4
         cipher = ARC4.new(key[::-1])
         command = cipher.encrypt('token::whoami\x00'.encode('utf-16le'))
         #command = cipher.encrypt('sekurlsa::logonPasswords\x00'.encode('utf-16le'))

--- a/tests/SMB_RPC/test_nrpc.py
+++ b/tests/SMB_RPC/test_nrpc.py
@@ -559,7 +559,7 @@ class NRPCTests(unittest.TestCase):
             lmhash = ntlm.LMOWFv1(self.password)
             nthash = ntlm.NTOWFv1(self.password)
         try:
-            from Crypto.Cipher import ARC4
+            from Cryptodome.Cipher import ARC4
         except Exception:
             print "Warning: You don't have any crypto installed. You need PyCrypto"
             print "See http://www.pycrypto.org/"
@@ -596,7 +596,7 @@ class NRPCTests(unittest.TestCase):
             nthash = ntlm.NTOWFv1(self.password)
 
         try:
-            from Crypto.Cipher import ARC4
+            from Cryptodome.Cipher import ARC4
         except Exception:
             print "Warning: You don't have any crypto installed. You need PyCrypto"
             print "See http://www.pycrypto.org/"
@@ -640,7 +640,7 @@ class NRPCTests(unittest.TestCase):
             nthash = ntlm.NTOWFv1(self.password)
 
         try:
-            from Crypto.Cipher import ARC4
+            from Cryptodome.Cipher import ARC4
         except Exception:
             print "Warning: You don't have any crypto installed. You need PyCrypto"
             print "See http://www.pycrypto.org/"

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -112,7 +112,7 @@ class NTLMTests(unittest.TestCase):
 
         print("4.2.2.4 GSS_WrapEx")
         print("Output of SEAL()")
-        from Crypto.Cipher import ARC4
+        from Cryptodome.Cipher import ARC4
         cipher = ARC4.new(self.randomSessionKey)
         handle = cipher.encrypt
         print("Plaintext")
@@ -184,7 +184,7 @@ class NTLMTests(unittest.TestCase):
         clientSealingKey = ntlm.SEALKEY(flags, exportedSessionKey)
         serverSealingKey = ntlm.SEALKEY(flags, exportedSessionKey, "Server")
 
-        from Crypto.Cipher import ARC4
+        from Cryptodome.Cipher import ARC4
         cipher = ARC4.new(clientSigningKey)
         client_signing_h = cipher.encrypt
 
@@ -276,7 +276,7 @@ class NTLMTests(unittest.TestCase):
         clientSealingKey = ntlm.SEALKEY(flags, exportedSessionKey)
         serverSealingKey = ntlm.SEALKEY(flags, exportedSessionKey, "Server")
 
-        from Crypto.Cipher import ARC4
+        from Cryptodome.Cipher import ARC4
         cipher = ARC4.new(clientSigningKey)
         client_signing_h = cipher.encrypt
 

--- a/tests/SMB_RPC/test_samr.py
+++ b/tests/SMB_RPC/test_samr.py
@@ -2688,7 +2688,7 @@ class SAMRTests(unittest.TestCase):
         newPwdHashLM = ntlm.LMOWFv1(newPwd)
 
         try:
-            from Crypto.Cipher import ARC4
+            from Cryptodome.Cipher import ARC4
         except Exception:
             print "Warning: You don't have any crypto installed. You need PyCrypto"
             print "See http://www.pycrypto.org/"
@@ -2755,7 +2755,7 @@ class SAMRTests(unittest.TestCase):
         newPwdHashLM = ntlm.LMOWFv1(newPwd)
 
         try:
-            from Crypto.Cipher import ARC4
+            from Cryptodome.Cipher import ARC4
         except Exception:
             print "Warning: You don't have any crypto installed. You need PyCrypto"
             print "See http://www.pycrypto.org/"


### PR DESCRIPTION
This PR replaces the deprecated and unmaintained `pycrypto` with `pycryptodome` as suggested in #336 

The requirements now include `pycryptodomex`, this is because there are two ways to install `pycryptodome`, as with their documentation https://www.pycryptodome.org/en/latest/src/introduction.html
The `pycryptodome` uses the same namespace as `pycrypto`, which would require the minimal amount of changes in the code, but it will conflict with `pycrypto` if it is installed on the same system (which we should avoid). This is why I've used `pycryptodomex`, which uses a different namespace but can be installed alongside the older `pycrypto`.

After the changes the tests run still fine (for as far as they didn't already break against my Server 2016 DC), and I've confirmed this also makes `AES.MODE_CCM` available (which is great for SMB3), installs without having to install compiler tools on Windows, and runs BloodHound.py succesfully.

The only additional changes are explicitly specifying `AES.MODE_ECB` in crypto.py, as this default is no longer supported in `pycryptodome`.