### PR TITLE
Fix "no pre-auth and RC4" handling in GetKerberosTGT

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -169,15 +169,16 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         # Yes
         preAuth = False
 
+    encryptionTypesData = dict()
+    salt = ''
     if preAuth is False:
         # In theory, we should have the right credentials for the etype specified before.
         methods = asRep['padata']
+        encryptionTypesData[supportedCiphers[0]] = salt # handle RC4 fallback, we don't need any salt
         tgt = r
     else:
         methods = decoder.decode(str(asRep['e-data']), asn1Spec=METHOD_DATA())[0]
 
-    salt = ''
-    encryptionTypesData = dict()
     for method in methods:
         if method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO2.value:
             etypes2 = decoder.decode(str(method['padata-value']), asn1Spec = ETYPE_INFO2())[0]


### PR DESCRIPTION
When there was no pre-authentication and server doesn't handle other
cipher suites than RC4, the encryptionTypesData table remained empty,
leading to a KeyError while deriving NTLM hash from password.

We now populate the encryptionTypesData table with an empty salt (not
needed with RC4) when pre-auth is disabled.