### PR TITLE
Use pycryptodome instead of PyCrypto library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name = PACKAGE_NAME,
                 'impacket.examples.ntlmrelayx.attacks'],
       scripts = glob.glob(os.path.join('examples', '*.py')),
       data_files = data_files,
-      install_requires=['pyasn1>=0.2.3', 'pycrypto>=2.6.1', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump', 'flask>=1.0'],
+      install_requires=['pyasn1>=0.2.3', 'pycryptodome', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump', 'flask>=1.0'],
       extras_require={
                       'pyreadline:sys_platform=="win32"': [],
                       ':python_version<"2.7"': [ 'argparse' ],
@@ -47,4 +47,3 @@ setup(name = PACKAGE_NAME,
           "Programming Language :: Python :: 2.6",
       ]
       )
-


### PR DESCRIPTION
Pycryptodome uses pure python implementation, so it matters in case of Windows installation.